### PR TITLE
feat(#22): Registro e invitación familiar

### DIFF
--- a/app/src/main/java/com/monghit/familytrack/MainActivity.kt
+++ b/app/src/main/java/com/monghit/familytrack/MainActivity.kt
@@ -8,12 +8,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import com.monghit.familytrack.data.repository.SettingsRepository
 import com.monghit.familytrack.ui.navigation.FamilyTrackNavHost
 import com.monghit.familytrack.ui.theme.FamilyTrackTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var settingsRepository: SettingsRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -24,7 +30,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    FamilyTrackNavHost()
+                    FamilyTrackNavHost(settingsRepository = settingsRepository)
                 }
             }
         }

--- a/app/src/main/java/com/monghit/familytrack/data/remote/ApiService.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/remote/ApiService.kt
@@ -2,11 +2,15 @@ package com.monghit.familytrack.data.remote
 
 import com.monghit.familytrack.data.remote.dto.ConfigUpdateRequest
 import com.monghit.familytrack.data.remote.dto.ConfigUpdateResponse
+import com.monghit.familytrack.data.remote.dto.CreateFamilyRequest
+import com.monghit.familytrack.data.remote.dto.CreateFamilyResponse
 import com.monghit.familytrack.data.remote.dto.CreateSafeZoneRequest
 import com.monghit.familytrack.data.remote.dto.CreateSafeZoneResponse
 import com.monghit.familytrack.data.remote.dto.DeleteSafeZoneRequest
 import com.monghit.familytrack.data.remote.dto.DeleteSafeZoneResponse
 import com.monghit.familytrack.data.remote.dto.FamilyLocationsResponse
+import com.monghit.familytrack.data.remote.dto.JoinFamilyRequest
+import com.monghit.familytrack.data.remote.dto.JoinFamilyResponse
 import com.monghit.familytrack.data.remote.dto.LocationUpdateRequest
 import com.monghit.familytrack.data.remote.dto.ManualNotifyRequest
 import com.monghit.familytrack.data.remote.dto.RegisterDeviceRequest
@@ -52,4 +56,14 @@ interface ApiService {
     suspend fun deleteSafeZone(
         @Body request: DeleteSafeZoneRequest
     ): Response<DeleteSafeZoneResponse>
+
+    @POST("api/family/create")
+    suspend fun createFamily(
+        @Body request: CreateFamilyRequest
+    ): Response<CreateFamilyResponse>
+
+    @POST("api/family/join")
+    suspend fun joinFamily(
+        @Body request: JoinFamilyRequest
+    ): Response<JoinFamilyResponse>
 }

--- a/app/src/main/java/com/monghit/familytrack/data/remote/dto/ApiDtos.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/remote/dto/ApiDtos.kt
@@ -117,3 +117,31 @@ data class DeleteSafeZoneResponse(
     @SerializedName("zoneId") val zoneId: Int,
     @SerializedName("name") val name: String
 )
+
+// Family Registration
+data class CreateFamilyRequest(
+    @SerializedName("familyName") val familyName: String,
+    @SerializedName("userName") val userName: String
+)
+
+data class CreateFamilyResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("familyId") val familyId: Int,
+    @SerializedName("familyName") val familyName: String,
+    @SerializedName("inviteCode") val inviteCode: String,
+    @SerializedName("role") val role: String
+)
+
+data class JoinFamilyRequest(
+    @SerializedName("inviteCode") val inviteCode: String,
+    @SerializedName("userName") val userName: String
+)
+
+data class JoinFamilyResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("familyId") val familyId: Int,
+    @SerializedName("familyName") val familyName: String,
+    @SerializedName("role") val role: String
+)

--- a/app/src/main/java/com/monghit/familytrack/data/repository/LocationRepository.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/repository/LocationRepository.kt
@@ -1,8 +1,10 @@
 package com.monghit.familytrack.data.repository
 
 import com.monghit.familytrack.data.remote.ApiService
+import com.monghit.familytrack.data.remote.dto.CreateFamilyRequest
 import com.monghit.familytrack.data.remote.dto.CreateSafeZoneRequest
 import com.monghit.familytrack.data.remote.dto.DeleteSafeZoneRequest
+import com.monghit.familytrack.data.remote.dto.JoinFamilyRequest
 import com.monghit.familytrack.data.remote.dto.LocationUpdateRequest
 import com.monghit.familytrack.data.remote.dto.ManualNotifyRequest
 import com.monghit.familytrack.data.remote.dto.RegisterDeviceRequest
@@ -212,6 +214,53 @@ class LocationRepository @Inject constructor(
             }
         } catch (e: Exception) {
             Timber.e(e, "Error deleting safe zone")
+            Result.failure(e)
+        }
+    }
+
+    suspend fun createFamily(familyName: String, userName: String): Result<Triple<Int, Int, String>> {
+        return try {
+            val request = CreateFamilyRequest(familyName = familyName, userName = userName)
+            val response = apiService.createFamily(request)
+            if (response.isSuccessful && response.body() != null) {
+                val body = response.body()!!
+                settingsRepository.setUserId(body.userId)
+                settingsRepository.setUserName(userName)
+                settingsRepository.setFamilyId(body.familyId)
+                settingsRepository.setFamilyName(body.familyName)
+                settingsRepository.setInviteCode(body.inviteCode)
+                settingsRepository.setUserRole(body.role)
+                Result.success(Triple(body.userId, body.familyId, body.inviteCode))
+            } else {
+                Result.failure(Exception("Failed to create family: ${response.message()}"))
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error creating family")
+            Result.failure(e)
+        }
+    }
+
+    suspend fun joinFamily(inviteCode: String, userName: String): Result<Pair<Int, Int>> {
+        return try {
+            val request = JoinFamilyRequest(inviteCode = inviteCode, userName = userName)
+            val response = apiService.joinFamily(request)
+            if (response.isSuccessful && response.body() != null) {
+                val body = response.body()!!
+                if (body.success) {
+                    settingsRepository.setUserId(body.userId)
+                    settingsRepository.setUserName(userName)
+                    settingsRepository.setFamilyId(body.familyId)
+                    settingsRepository.setFamilyName(body.familyName)
+                    settingsRepository.setUserRole(body.role)
+                    Result.success(Pair(body.userId, body.familyId))
+                } else {
+                    Result.failure(Exception("Invalid invite code"))
+                }
+            } else {
+                Result.failure(Exception("Invalid invite code"))
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error joining family")
             Result.failure(e)
         }
     }

--- a/app/src/main/java/com/monghit/familytrack/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/repository/SettingsRepository.kt
@@ -32,6 +32,10 @@ class SettingsRepository @Inject constructor(
         val DEVICE_ID = intPreferencesKey("device_id")
         val IS_REGISTERED = booleanPreferencesKey("is_registered")
         val LAST_LOCATION_UPDATE = longPreferencesKey("last_location_update")
+        val FAMILY_ID = intPreferencesKey("family_id")
+        val FAMILY_NAME = stringPreferencesKey("family_name")
+        val INVITE_CODE = stringPreferencesKey("invite_code")
+        val USER_ROLE = stringPreferencesKey("user_role")
     }
 
     val isLocationEnabled: Flow<Boolean> = context.dataStore.data
@@ -82,6 +86,26 @@ class SettingsRepository @Inject constructor(
     val lastLocationUpdate: Flow<Long> = context.dataStore.data
         .map { preferences ->
             preferences[PreferencesKeys.LAST_LOCATION_UPDATE] ?: 0L
+        }
+
+    val familyId: Flow<Int> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.FAMILY_ID] ?: 0
+        }
+
+    val familyName: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.FAMILY_NAME] ?: ""
+        }
+
+    val inviteCode: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.INVITE_CODE] ?: ""
+        }
+
+    val userRole: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.USER_ROLE] ?: ""
         }
 
     suspend fun setLocationEnabled(enabled: Boolean) {
@@ -141,6 +165,30 @@ class SettingsRepository @Inject constructor(
     suspend fun setLastLocationUpdate(timestamp: Long) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.LAST_LOCATION_UPDATE] = timestamp
+        }
+    }
+
+    suspend fun setFamilyId(id: Int) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.FAMILY_ID] = id
+        }
+    }
+
+    suspend fun setFamilyName(name: String) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.FAMILY_NAME] = name
+        }
+    }
+
+    suspend fun setInviteCode(code: String) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.INVITE_CODE] = code
+        }
+    }
+
+    suspend fun setUserRole(role: String) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.USER_ROLE] = role
         }
     }
 

--- a/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
@@ -7,4 +7,5 @@ sealed class NavRoutes(val route: String) {
     data object Settings : NavRoutes("settings")
     data object SafeZones : NavRoutes("safe_zones")
     data object Permissions : NavRoutes("permissions")
+    data object FamilySetup : NavRoutes("family_setup")
 }

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/familysetup/FamilySetupScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/familysetup/FamilySetupScreen.kt
@@ -1,0 +1,394 @@
+package com.monghit.familytrack.ui.screens.familysetup
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.GroupAdd
+import androidx.compose.material.icons.filled.Groups
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun FamilySetupScreen(
+    onSetupComplete: () -> Unit,
+    viewModel: FamilySetupViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    AnimatedContent(targetState = uiState.step, label = "setup_step") { step ->
+        when (step) {
+            SetupStep.CHOOSE -> ChooseStep(
+                onCreateClick = viewModel::goToCreate,
+                onJoinClick = viewModel::goToJoin
+            )
+            SetupStep.CREATE_FAMILY -> CreateFamilyStep(
+                uiState = uiState,
+                onUserNameChange = viewModel::updateUserName,
+                onFamilyNameChange = viewModel::updateFamilyName,
+                onCreateClick = viewModel::createFamily,
+                onBackClick = viewModel::goBack
+            )
+            SetupStep.JOIN_FAMILY -> JoinFamilyStep(
+                uiState = uiState,
+                onUserNameChange = viewModel::updateUserName,
+                onInviteCodeChange = viewModel::updateInviteCode,
+                onJoinClick = viewModel::joinFamily,
+                onBackClick = viewModel::goBack
+            )
+            SetupStep.SUCCESS -> SuccessStep(
+                inviteCode = uiState.resultInviteCode,
+                familyName = uiState.resultFamilyName,
+                onContinue = onSetupComplete
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChooseStep(
+    onCreateClick: () -> Unit,
+    onJoinClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Groups,
+            contentDescription = null,
+            modifier = Modifier.size(80.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "FamilyTrack",
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Mantente conectado con tu familia",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(48.dp))
+
+        Button(
+            onClick = onCreateClick,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(Icons.Filled.GroupAdd, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Crear familia")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            onClick = onJoinClick,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Icon(Icons.Filled.PersonAdd, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text("Unirme a una familia")
+        }
+    }
+}
+
+@Composable
+private fun CreateFamilyStep(
+    uiState: FamilySetupUiState,
+    onUserNameChange: (String) -> Unit,
+    onFamilyNameChange: (String) -> Unit,
+    onCreateClick: () -> Unit,
+    onBackClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+    ) {
+        IconButton(onClick = onBackClick) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Crear familia",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Serás el administrador de tu familia",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        OutlinedTextField(
+            value = uiState.userName,
+            onValueChange = onUserNameChange,
+            label = { Text("Tu nombre") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Words,
+                imeAction = ImeAction.Next
+            )
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = uiState.familyName,
+            onValueChange = onFamilyNameChange,
+            label = { Text("Nombre de la familia") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Words,
+                imeAction = ImeAction.Done
+            )
+        )
+
+        if (uiState.error != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = uiState.error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = onCreateClick,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !uiState.isLoading
+        ) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp
+                )
+            } else {
+                Text("Crear familia")
+            }
+        }
+    }
+}
+
+@Composable
+private fun JoinFamilyStep(
+    uiState: FamilySetupUiState,
+    onUserNameChange: (String) -> Unit,
+    onInviteCodeChange: (String) -> Unit,
+    onJoinClick: () -> Unit,
+    onBackClick: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp)
+    ) {
+        IconButton(onClick = onBackClick) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "Unirme a familia",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Introduce el código de invitación que te compartieron",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        OutlinedTextField(
+            value = uiState.userName,
+            onValueChange = onUserNameChange,
+            label = { Text("Tu nombre") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Words,
+                imeAction = ImeAction.Next
+            )
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = uiState.inviteCode,
+            onValueChange = onInviteCodeChange,
+            label = { Text("Código de invitación") },
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Characters,
+                imeAction = ImeAction.Done
+            )
+        )
+
+        if (uiState.error != null) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = uiState.error,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Button(
+            onClick = onJoinClick,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !uiState.isLoading
+        ) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp
+                )
+            } else {
+                Text("Unirme")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SuccessStep(
+    inviteCode: String,
+    familyName: String,
+    onContinue: () -> Unit
+) {
+    val clipboardManager = LocalClipboardManager.current
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Groups,
+            contentDescription = null,
+            modifier = Modifier.size(80.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "Familia configurada",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        if (inviteCode.isNotBlank()) {
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Comparte este código con tu familia:",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer
+                )
+            ) {
+                Row(
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = inviteCode,
+                        style = MaterialTheme.typography.headlineLarge,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = MaterialTheme.typography.headlineLarge.letterSpacing * 2
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    IconButton(onClick = {
+                        clipboardManager.setText(AnnotatedString(inviteCode))
+                    }) {
+                        Icon(Icons.Filled.ContentCopy, contentDescription = "Copiar código")
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(48.dp))
+
+        Button(
+            onClick = onContinue,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("Continuar")
+        }
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/familysetup/FamilySetupViewModel.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/familysetup/FamilySetupViewModel.kt
@@ -1,0 +1,116 @@
+package com.monghit.familytrack.ui.screens.familysetup
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.monghit.familytrack.data.repository.LocationRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+enum class SetupStep {
+    CHOOSE,
+    CREATE_FAMILY,
+    JOIN_FAMILY,
+    SUCCESS
+}
+
+data class FamilySetupUiState(
+    val step: SetupStep = SetupStep.CHOOSE,
+    val userName: String = "",
+    val familyName: String = "",
+    val inviteCode: String = "",
+    val resultInviteCode: String = "",
+    val resultFamilyName: String = "",
+    val isLoading: Boolean = false,
+    val error: String? = null
+)
+
+@HiltViewModel
+class FamilySetupViewModel @Inject constructor(
+    private val locationRepository: LocationRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(FamilySetupUiState())
+    val uiState: StateFlow<FamilySetupUiState> = _uiState.asStateFlow()
+
+    fun goToCreate() {
+        _uiState.update { it.copy(step = SetupStep.CREATE_FAMILY, error = null) }
+    }
+
+    fun goToJoin() {
+        _uiState.update { it.copy(step = SetupStep.JOIN_FAMILY, error = null) }
+    }
+
+    fun goBack() {
+        _uiState.update { it.copy(step = SetupStep.CHOOSE, error = null) }
+    }
+
+    fun updateUserName(name: String) {
+        _uiState.update { it.copy(userName = name) }
+    }
+
+    fun updateFamilyName(name: String) {
+        _uiState.update { it.copy(familyName = name) }
+    }
+
+    fun updateInviteCode(code: String) {
+        _uiState.update { it.copy(inviteCode = code.uppercase().take(6)) }
+    }
+
+    fun createFamily() {
+        val state = _uiState.value
+        if (state.userName.isBlank() || state.familyName.isBlank()) {
+            _uiState.update { it.copy(error = "Completa todos los campos") }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            val result = locationRepository.createFamily(state.familyName, state.userName)
+            result.onSuccess { (_, _, inviteCode) ->
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        step = SetupStep.SUCCESS,
+                        resultInviteCode = inviteCode,
+                        resultFamilyName = state.familyName
+                    )
+                }
+            }.onFailure { error ->
+                _uiState.update {
+                    it.copy(isLoading = false, error = error.message ?: "Error al crear familia")
+                }
+            }
+        }
+    }
+
+    fun joinFamily() {
+        val state = _uiState.value
+        if (state.userName.isBlank() || state.inviteCode.length != 6) {
+            _uiState.update { it.copy(error = "Introduce tu nombre y el código de 6 caracteres") }
+            return
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            val result = locationRepository.joinFamily(state.inviteCode, state.userName)
+            result.onSuccess { (_, _) ->
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        step = SetupStep.SUCCESS,
+                        resultFamilyName = ""
+                    )
+                }
+            }.onFailure { error ->
+                _uiState.update {
+                    it.copy(isLoading = false, error = "Código de invitación inválido")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `families` table in PostgreSQL with invite code system
- n8n workflows for `POST /api/family/create` and `POST /api/family/join`
- FamilySetupScreen with create/join family flow (4-step wizard)
- Navigation updated to show setup screen when no family configured
- Family data persisted in DataStore (familyId, familyName, inviteCode, userRole)

Closes #22

## Test plan
- [ ] Create a new family and verify invite code is generated
- [ ] Join existing family with valid invite code
- [ ] Verify invalid invite code shows error
- [ ] Verify app shows main screen after family setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)