### PR TITLE
feat(#23): Login con PIN/biometría

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,10 @@ dependencies {
     // Permissions
     implementation(libs.accompanist.permissions)
 
+    // Biometric & Security
+    implementation(libs.biometric)
+    implementation(libs.security.crypto)
+
     // Testing
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/monghit/familytrack/MainActivity.kt
+++ b/app/src/main/java/com/monghit/familytrack/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import com.monghit.familytrack.data.repository.SecurityRepository
 import com.monghit.familytrack.data.repository.SettingsRepository
 import com.monghit.familytrack.ui.navigation.FamilyTrackNavHost
 import com.monghit.familytrack.ui.theme.FamilyTrackTheme
@@ -20,6 +21,9 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var settingsRepository: SettingsRepository
 
+    @Inject
+    lateinit var securityRepository: SecurityRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -30,7 +34,10 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    FamilyTrackNavHost(settingsRepository = settingsRepository)
+                    FamilyTrackNavHost(
+                        settingsRepository = settingsRepository,
+                        securityRepository = securityRepository
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/monghit/familytrack/data/repository/SecurityRepository.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/repository/SecurityRepository.kt
@@ -1,0 +1,67 @@
+package com.monghit.familytrack.data.repository
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.security.MessageDigest
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SecurityRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val masterKeyAlias = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+
+    private val prefs: SharedPreferences = EncryptedSharedPreferences.create(
+        "security_prefs",
+        masterKeyAlias,
+        context,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    fun isPinSet(): Boolean = prefs.contains(KEY_PIN_HASH)
+
+    fun isBiometricEnabled(): Boolean = prefs.getBoolean(KEY_BIOMETRIC_ENABLED, false)
+
+    fun getAutoLockMinutes(): Int = prefs.getInt(KEY_AUTO_LOCK_MINUTES, 5)
+
+    fun setPin(pin: String) {
+        prefs.edit().putString(KEY_PIN_HASH, hashPin(pin)).apply()
+    }
+
+    fun verifyPin(pin: String): Boolean {
+        val storedHash = prefs.getString(KEY_PIN_HASH, null) ?: return false
+        return storedHash == hashPin(pin)
+    }
+
+    fun setBiometricEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_BIOMETRIC_ENABLED, enabled).apply()
+    }
+
+    fun setAutoLockMinutes(minutes: Int) {
+        prefs.edit().putInt(KEY_AUTO_LOCK_MINUTES, minutes).apply()
+    }
+
+    fun clearPin() {
+        prefs.edit()
+            .remove(KEY_PIN_HASH)
+            .putBoolean(KEY_BIOMETRIC_ENABLED, false)
+            .apply()
+    }
+
+    private fun hashPin(pin: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hashBytes = digest.digest(pin.toByteArray())
+        return hashBytes.joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        private const val KEY_PIN_HASH = "pin_hash"
+        private const val KEY_BIOMETRIC_ENABLED = "biometric_enabled"
+        private const val KEY_AUTO_LOCK_MINUTES = "auto_lock_minutes"
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/di/AppModule.kt
+++ b/app/src/main/java/com/monghit/familytrack/di/AppModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.monghit.familytrack.BuildConfig
 import com.monghit.familytrack.data.remote.ApiService
 import com.monghit.familytrack.data.repository.LocationRepository
+import com.monghit.familytrack.data.repository.SecurityRepository
 import com.monghit.familytrack.data.repository.SettingsRepository
 import dagger.Module
 import dagger.Provides
@@ -62,6 +63,14 @@ object AppModule {
         @ApplicationContext context: Context
     ): SettingsRepository {
         return SettingsRepository(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSecurityRepository(
+        @ApplicationContext context: Context
+    ): SecurityRepository {
+        return SecurityRepository(context)
     }
 
     @Provides

--- a/app/src/main/java/com/monghit/familytrack/services/BiometricHelper.kt
+++ b/app/src/main/java/com/monghit/familytrack/services/BiometricHelper.kt
@@ -1,0 +1,55 @@
+package com.monghit.familytrack.services
+
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+
+object BiometricHelper {
+
+    fun canUseBiometric(activity: FragmentActivity): Boolean {
+        val biometricManager = BiometricManager.from(activity)
+        return biometricManager.canAuthenticate(
+            BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                BiometricManager.Authenticators.BIOMETRIC_WEAK
+        ) == BiometricManager.BIOMETRIC_SUCCESS
+    }
+
+    fun authenticate(
+        activity: FragmentActivity,
+        onSuccess: () -> Unit,
+        onError: (String) -> Unit
+    ) {
+        val executor = ContextCompat.getMainExecutor(activity)
+
+        val callback = object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                onSuccess()
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                if (errorCode != BiometricPrompt.ERROR_USER_CANCELED &&
+                    errorCode != BiometricPrompt.ERROR_NEGATIVE_BUTTON
+                ) {
+                    onError(errString.toString())
+                }
+            }
+
+            override fun onAuthenticationFailed() {
+                // User can retry, no action needed
+            }
+        }
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle("FamilyTrack")
+            .setSubtitle("Usa tu huella o rostro para acceder")
+            .setNegativeButtonText("Usar PIN")
+            .setAllowedAuthenticators(
+                BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                    BiometricManager.Authenticators.BIOMETRIC_WEAK
+            )
+            .build()
+
+        BiometricPrompt(activity, executor, callback).authenticate(promptInfo)
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
@@ -8,4 +8,5 @@ sealed class NavRoutes(val route: String) {
     data object SafeZones : NavRoutes("safe_zones")
     data object Permissions : NavRoutes("permissions")
     data object FamilySetup : NavRoutes("family_setup")
+    data object PinLock : NavRoutes("pin_lock")
 }

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/pin/PinScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/pin/PinScreen.kt
@@ -1,0 +1,195 @@
+package com.monghit.familytrack.ui.screens.pin
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Backspace
+import androidx.compose.material.icons.filled.Fingerprint
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.monghit.familytrack.services.BiometricHelper
+
+@Composable
+fun PinScreen(
+    onAuthenticated: () -> Unit,
+    viewModel: PinViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(uiState.isAuthenticated) {
+        if (uiState.isAuthenticated) {
+            onAuthenticated()
+        }
+    }
+
+    LaunchedEffect(uiState.biometricAvailable) {
+        if (uiState.biometricAvailable && uiState.mode == PinMode.VERIFY) {
+            val activity = context as? FragmentActivity ?: return@LaunchedEffect
+            if (BiometricHelper.canUseBiometric(activity)) {
+                BiometricHelper.authenticate(
+                    activity = activity,
+                    onSuccess = { viewModel.onBiometricSuccess() },
+                    onError = { }
+                )
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = when (uiState.mode) {
+                PinMode.CREATE -> "Crear PIN"
+                PinMode.CONFIRM -> "Confirmar PIN"
+                PinMode.VERIFY -> "Introduce tu PIN"
+            },
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = when (uiState.mode) {
+                PinMode.CREATE -> "Elige un PIN de 4 dígitos"
+                PinMode.CONFIRM -> "Repite el PIN para confirmar"
+                PinMode.VERIFY -> "Desbloquea FamilyTrack"
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // PIN dots
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            repeat(4) { index ->
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (index < uiState.pin.length)
+                                MaterialTheme.colorScheme.primary
+                            else
+                                MaterialTheme.colorScheme.outlineVariant
+                        )
+                )
+            }
+        }
+
+        if (uiState.error != null) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = uiState.error!!,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center
+            )
+        }
+
+        Spacer(modifier = Modifier.height(48.dp))
+
+        // Numpad
+        val digits = listOf(
+            listOf('1', '2', '3'),
+            listOf('4', '5', '6'),
+            listOf('7', '8', '9'),
+            listOf(' ', '0', 'D')
+        )
+
+        digits.forEach { row ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(24.dp),
+                modifier = Modifier.padding(vertical = 8.dp)
+            ) {
+                row.forEach { char ->
+                    when (char) {
+                        ' ' -> {
+                            if (uiState.biometricAvailable && uiState.mode == PinMode.VERIFY) {
+                                IconButton(
+                                    onClick = {
+                                        val activity = context as? FragmentActivity ?: return@IconButton
+                                        BiometricHelper.authenticate(
+                                            activity = activity,
+                                            onSuccess = { viewModel.onBiometricSuccess() },
+                                            onError = { }
+                                        )
+                                    },
+                                    modifier = Modifier.size(64.dp)
+                                ) {
+                                    Icon(
+                                        Icons.Filled.Fingerprint,
+                                        contentDescription = "Biometría",
+                                        modifier = Modifier.size(32.dp)
+                                    )
+                                }
+                            } else {
+                                Spacer(modifier = Modifier.size(64.dp))
+                            }
+                        }
+                        'D' -> {
+                            IconButton(
+                                onClick = { viewModel.onDelete() },
+                                modifier = Modifier.size(64.dp)
+                            ) {
+                                Icon(
+                                    Icons.Filled.Backspace,
+                                    contentDescription = "Borrar",
+                                    modifier = Modifier.size(28.dp)
+                                )
+                            }
+                        }
+                        else -> {
+                            Box(
+                                modifier = Modifier
+                                    .size(64.dp)
+                                    .clip(CircleShape)
+                                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                                    .clickable { viewModel.onDigit(char) },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = char.toString(),
+                                    style = MaterialTheme.typography.headlineMedium,
+                                    fontWeight = FontWeight.Medium
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/pin/PinViewModel.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/pin/PinViewModel.kt
@@ -1,0 +1,100 @@
+package com.monghit.familytrack.ui.screens.pin
+
+import androidx.lifecycle.ViewModel
+import com.monghit.familytrack.data.repository.SecurityRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+enum class PinMode {
+    CREATE,
+    CONFIRM,
+    VERIFY
+}
+
+data class PinUiState(
+    val mode: PinMode = PinMode.VERIFY,
+    val pin: String = "",
+    val firstPin: String = "",
+    val error: String? = null,
+    val isAuthenticated: Boolean = false,
+    val biometricAvailable: Boolean = false
+)
+
+@HiltViewModel
+class PinViewModel @Inject constructor(
+    private val securityRepository: SecurityRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PinUiState())
+    val uiState: StateFlow<PinUiState> = _uiState.asStateFlow()
+
+    init {
+        val isPinSet = securityRepository.isPinSet()
+        _uiState.update {
+            it.copy(
+                mode = if (isPinSet) PinMode.VERIFY else PinMode.CREATE,
+                biometricAvailable = securityRepository.isBiometricEnabled()
+            )
+        }
+    }
+
+    fun onDigit(digit: Char) {
+        val current = _uiState.value
+        if (current.pin.length >= 4) return
+
+        val newPin = current.pin + digit
+        _uiState.update { it.copy(pin = newPin, error = null) }
+
+        if (newPin.length == 4) {
+            when (current.mode) {
+                PinMode.CREATE -> {
+                    _uiState.update {
+                        it.copy(
+                            mode = PinMode.CONFIRM,
+                            firstPin = newPin,
+                            pin = ""
+                        )
+                    }
+                }
+                PinMode.CONFIRM -> {
+                    if (newPin == current.firstPin) {
+                        securityRepository.setPin(newPin)
+                        _uiState.update { it.copy(isAuthenticated = true) }
+                    } else {
+                        _uiState.update {
+                            it.copy(
+                                mode = PinMode.CREATE,
+                                pin = "",
+                                firstPin = "",
+                                error = "Los PINs no coinciden. Inténtalo de nuevo."
+                            )
+                        }
+                    }
+                }
+                PinMode.VERIFY -> {
+                    if (securityRepository.verifyPin(newPin)) {
+                        _uiState.update { it.copy(isAuthenticated = true) }
+                    } else {
+                        _uiState.update {
+                            it.copy(pin = "", error = "PIN incorrecto")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun onDelete() {
+        _uiState.update {
+            it.copy(pin = it.pin.dropLast(1), error = null)
+        }
+    }
+
+    fun onBiometricSuccess() {
+        _uiState.update { it.copy(isAuthenticated = true) }
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
 import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Notifications
@@ -103,6 +105,33 @@ fun SettingsScreen(
                     checked = uiState.notificationsEnabled,
                     onCheckedChange = viewModel::toggleNotifications
                 )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Security Section
+            SettingsSection(
+                title = "Seguridad",
+                icon = Icons.Default.Lock
+            ) {
+                SettingsSwitchItem(
+                    title = "Bloqueo con PIN",
+                    checked = uiState.isPinSet,
+                    onCheckedChange = { enabled ->
+                        if (!enabled) {
+                            viewModel.togglePinEnabled(false)
+                        }
+                        // PIN creation is handled via PinScreen navigation
+                    }
+                )
+                if (uiState.isPinSet) {
+                    HorizontalDivider()
+                    SettingsSwitchItem(
+                        title = "Desbloqueo biométrico",
+                        checked = uiState.isBiometricEnabled,
+                        onCheckedChange = viewModel::toggleBiometric
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ junit = "4.13.2"
 junitExt = "1.2.1"
 espressoCore = "3.6.1"
 accompanist = "0.34.0"
+biometric = "1.1.0"
+securityCrypto = "1.0.0"
 
 [libraries]
 # AndroidX Core
@@ -92,6 +94,10 @@ timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "tim
 
 # Accompanist
 accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
+
+# Biometric & Security
+biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
+security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary
- SecurityRepository with EncryptedSharedPreferences for secure PIN storage
- PinScreen with 4-digit numpad (create/confirm/verify modes)
- BiometricHelper wrapping BiometricPrompt for fingerprint/face auth
- PIN lock integrated in navigation (shown on app launch when PIN is set)
- Security settings section added to SettingsScreen

Closes #23

## Test plan
- [ ] Create 4-digit PIN on first use
- [ ] Verify PIN is required on app relaunch
- [ ] Enable biometric auth and test fingerprint unlock
- [ ] Disable PIN from settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)