### PR TITLE
feat(#24): perfil editable + chat familiar + backend v2

### DIFF
--- a/app/src/main/java/com/monghit/familytrack/data/remote/ApiService.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/remote/ApiService.kt
@@ -1,20 +1,6 @@
 package com.monghit.familytrack.data.remote
 
-import com.monghit.familytrack.data.remote.dto.ConfigUpdateRequest
-import com.monghit.familytrack.data.remote.dto.ConfigUpdateResponse
-import com.monghit.familytrack.data.remote.dto.CreateFamilyRequest
-import com.monghit.familytrack.data.remote.dto.CreateFamilyResponse
-import com.monghit.familytrack.data.remote.dto.CreateSafeZoneRequest
-import com.monghit.familytrack.data.remote.dto.CreateSafeZoneResponse
-import com.monghit.familytrack.data.remote.dto.DeleteSafeZoneRequest
-import com.monghit.familytrack.data.remote.dto.DeleteSafeZoneResponse
-import com.monghit.familytrack.data.remote.dto.FamilyLocationsResponse
-import com.monghit.familytrack.data.remote.dto.JoinFamilyRequest
-import com.monghit.familytrack.data.remote.dto.JoinFamilyResponse
-import com.monghit.familytrack.data.remote.dto.LocationUpdateRequest
-import com.monghit.familytrack.data.remote.dto.ManualNotifyRequest
-import com.monghit.familytrack.data.remote.dto.RegisterDeviceRequest
-import com.monghit.familytrack.data.remote.dto.RegisterDeviceResponse
+import com.monghit.familytrack.data.remote.dto.*
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -66,4 +52,50 @@ interface ApiService {
     suspend fun joinFamily(
         @Body request: JoinFamilyRequest
     ): Response<JoinFamilyResponse>
+
+    @POST("api/user/update-profile")
+    suspend fun updateProfile(
+        @Body request: UpdateProfileRequest
+    ): Response<UpdateProfileResponse>
+
+    @POST("api/user/profile")
+    suspend fun getProfile(
+        @Body request: GetProfileRequest
+    ): Response<GetProfileResponse>
+
+    @POST("api/quick-message")
+    suspend fun sendQuickMessage(
+        @Body request: QuickMessageRequest
+    ): Response<Unit>
+
+    @POST("api/emergency")
+    suspend fun sendEmergency(
+        @Body request: EmergencyRequest
+    ): Response<EmergencyResponse>
+
+    @GET("api/locations/history")
+    suspend fun getLocationHistory(
+        @Query("userId") userId: Int,
+        @Query("date") date: String
+    ): Response<LocationHistoryResponse>
+
+    @POST("api/chat/send")
+    suspend fun sendChatMessage(
+        @Body request: ChatSendRequest
+    ): Response<ChatSendResponse>
+
+    @POST("api/chat/messages")
+    suspend fun getChatMessages(
+        @Body request: ChatMessagesRequest
+    ): Response<ChatMessagesResponse>
+
+    @POST("api/photos/send")
+    suspend fun sendPhoto(
+        @Body request: PhotoSendRequest
+    ): Response<PhotoSendResponse>
+
+    @POST("api/photos/list")
+    suspend fun getPhotoList(
+        @Body request: PhotoListRequest
+    ): Response<PhotoListResponse>
 }

--- a/app/src/main/java/com/monghit/familytrack/data/remote/dto/ApiDtos.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/remote/dto/ApiDtos.kt
@@ -145,3 +145,120 @@ data class JoinFamilyResponse(
     @SerializedName("familyName") val familyName: String,
     @SerializedName("role") val role: String
 )
+
+// Profile
+data class UpdateProfileRequest(
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("name") val name: String,
+    @SerializedName("avatar") val avatar: String? = null
+)
+
+data class UpdateProfileResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("name") val name: String
+)
+
+data class GetProfileRequest(
+    @SerializedName("userId") val userId: Int
+)
+
+data class GetProfileResponse(
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("name") val name: String,
+    @SerializedName("role") val role: String,
+    @SerializedName("avatar") val avatar: String? = null,
+    @SerializedName("familyName") val familyName: String? = null,
+    @SerializedName("inviteCode") val inviteCode: String? = null
+)
+
+// Quick Message
+data class QuickMessageRequest(
+    @SerializedName("fromUserId") val fromUserId: Int,
+    @SerializedName("message") val message: String,
+    @SerializedName("latitude") val latitude: Double,
+    @SerializedName("longitude") val longitude: Double
+)
+
+// Emergency SOS
+data class EmergencyRequest(
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("latitude") val latitude: Double,
+    @SerializedName("longitude") val longitude: Double
+)
+
+data class EmergencyResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("alertId") val alertId: Int? = null
+)
+
+// Location History
+data class LocationHistoryResponse(
+    @SerializedName("locations") val locations: List<LocationHistoryDto>
+)
+
+data class LocationHistoryDto(
+    @SerializedName("latitude") val latitude: Double,
+    @SerializedName("longitude") val longitude: Double,
+    @SerializedName("accuracy") val accuracy: Float? = null,
+    @SerializedName("timestamp") val timestamp: String? = null
+)
+
+// Chat
+data class ChatSendRequest(
+    @SerializedName("fromUserId") val fromUserId: Int,
+    @SerializedName("content") val content: String
+)
+
+data class ChatSendResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("messageId") val messageId: Int? = null
+)
+
+data class ChatMessagesRequest(
+    @SerializedName("familyId") val familyId: Int,
+    @SerializedName("limit") val limit: Int = 50
+)
+
+data class ChatMessagesResponse(
+    @SerializedName("messages") val messages: List<ChatMessageDto>
+)
+
+data class ChatMessageDto(
+    @SerializedName("id") val id: Int,
+    @SerializedName("content") val content: String,
+    @SerializedName("createdAt") val createdAt: String,
+    @SerializedName("userId") val userId: Int,
+    @SerializedName("userName") val userName: String,
+    @SerializedName("avatar") val avatar: String? = null
+)
+
+// Photos
+data class PhotoSendRequest(
+    @SerializedName("fromUserId") val fromUserId: Int,
+    @SerializedName("toUserId") val toUserId: Int,
+    @SerializedName("imageData") val imageData: String,
+    @SerializedName("caption") val caption: String? = null
+)
+
+data class PhotoSendResponse(
+    @SerializedName("success") val success: Boolean,
+    @SerializedName("photoId") val photoId: Int? = null
+)
+
+data class PhotoListRequest(
+    @SerializedName("userId") val userId: Int
+)
+
+data class PhotoListResponse(
+    @SerializedName("photos") val photos: List<PhotoDto>
+)
+
+data class PhotoDto(
+    @SerializedName("id") val id: Int,
+    @SerializedName("fromUserId") val fromUserId: Int,
+    @SerializedName("fromName") val fromName: String,
+    @SerializedName("toUserId") val toUserId: Int,
+    @SerializedName("caption") val caption: String? = null,
+    @SerializedName("createdAt") val createdAt: String
+)

--- a/app/src/main/java/com/monghit/familytrack/ui/navigation/FamilyTrackNavHost.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/navigation/FamilyTrackNavHost.kt
@@ -35,6 +35,8 @@ import com.monghit.familytrack.ui.screens.familysetup.FamilySetupScreen
 import com.monghit.familytrack.ui.screens.pin.PinScreen
 import com.monghit.familytrack.ui.screens.home.HomeScreen
 import com.monghit.familytrack.ui.screens.map.MapScreen
+import com.monghit.familytrack.ui.screens.chat.ChatScreen
+import com.monghit.familytrack.ui.screens.profile.ProfileScreen
 import com.monghit.familytrack.ui.screens.safezones.SafeZonesScreen
 import com.monghit.familytrack.ui.screens.settings.SettingsScreen
 
@@ -164,7 +166,24 @@ fun FamilyTrackNavHost(
                 FamilyScreen()
             }
             composable(NavRoutes.Settings.route) {
-                SettingsScreen()
+                SettingsScreen(
+                    onNavigateToProfile = {
+                        navController.navigate(NavRoutes.Profile.route)
+                    },
+                    onNavigateToChat = {
+                        navController.navigate(NavRoutes.Chat.route)
+                    }
+                )
+            }
+            composable(NavRoutes.Profile.route) {
+                ProfileScreen(
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable(NavRoutes.Chat.route) {
+                ChatScreen(
+                    onNavigateBack = { navController.popBackStack() }
+                )
             }
             composable(NavRoutes.SafeZones.route) {
                 SafeZonesScreen(

--- a/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
@@ -9,4 +9,6 @@ sealed class NavRoutes(val route: String) {
     data object Permissions : NavRoutes("permissions")
     data object FamilySetup : NavRoutes("family_setup")
     data object PinLock : NavRoutes("pin_lock")
+    data object Profile : NavRoutes("profile")
+    data object Chat : NavRoutes("chat")
 }

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/chat/ChatScreen.kt
@@ -1,0 +1,193 @@
+package com.monghit.familytrack.ui.screens.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: ChatViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(uiState.messages.size) {
+        if (uiState.messages.isNotEmpty()) {
+            listState.animateScrollToItem(uiState.messages.size - 1)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Chat Familiar") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            if (uiState.isLoading) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else if (uiState.messages.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "No hay mensajes aun. Envia el primero!",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                LazyColumn(
+                    state = listState,
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(horizontal = 8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    items(uiState.messages, key = { it.id }) { message ->
+                        ChatBubble(message = message)
+                    }
+                }
+            }
+
+            // Input bar
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OutlinedTextField(
+                    value = uiState.inputText,
+                    onValueChange = viewModel::updateInput,
+                    modifier = Modifier.weight(1f),
+                    placeholder = { Text("Escribe un mensaje...") },
+                    singleLine = true,
+                    shape = RoundedCornerShape(24.dp)
+                )
+                IconButton(
+                    onClick = viewModel::sendMessage,
+                    enabled = uiState.inputText.isNotBlank() && !uiState.isSending
+                ) {
+                    if (uiState.isSending) {
+                        CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+                    } else {
+                        Icon(
+                            Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Enviar",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChatBubble(message: ChatMessage) {
+    val isOwn = message.isOwnMessage
+    val alignment = if (isOwn) Alignment.End else Alignment.Start
+    val bgColor = if (isOwn) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.secondaryContainer
+    }
+    val textColor = if (isOwn) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSecondaryContainer
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = alignment
+    ) {
+        if (!isOwn) {
+            Text(
+                text = message.userName,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(start = 12.dp, bottom = 2.dp)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .widthIn(max = 280.dp)
+                .clip(
+                    RoundedCornerShape(
+                        topStart = 16.dp,
+                        topEnd = 16.dp,
+                        bottomStart = if (isOwn) 16.dp else 4.dp,
+                        bottomEnd = if (isOwn) 4.dp else 16.dp
+                    )
+                )
+                .background(bgColor)
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        ) {
+            Text(
+                text = message.content,
+                color = textColor,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+        Spacer(modifier = Modifier.height(2.dp))
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/chat/ChatViewModel.kt
@@ -1,0 +1,114 @@
+package com.monghit.familytrack.ui.screens.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.monghit.familytrack.data.remote.ApiService
+import com.monghit.familytrack.data.remote.dto.ChatMessagesRequest
+import com.monghit.familytrack.data.remote.dto.ChatSendRequest
+import com.monghit.familytrack.data.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+data class ChatMessage(
+    val id: Int,
+    val content: String,
+    val createdAt: String,
+    val userId: Int,
+    val userName: String,
+    val isOwnMessage: Boolean
+)
+
+data class ChatUiState(
+    val messages: List<ChatMessage> = emptyList(),
+    val inputText: String = "",
+    val isLoading: Boolean = true,
+    val isSending: Boolean = false,
+    val currentUserId: Int = 0
+)
+
+@HiltViewModel
+class ChatViewModel @Inject constructor(
+    private val apiService: ApiService,
+    private val settingsRepository: SettingsRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ChatUiState())
+    val uiState: StateFlow<ChatUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            _uiState.update { it.copy(currentUserId = settingsRepository.userId.first()) }
+            loadMessages()
+            startPolling()
+        }
+    }
+
+    private suspend fun loadMessages() {
+        try {
+            val familyId = settingsRepository.familyId.first()
+            if (familyId == 0) return
+            val currentUserId = settingsRepository.userId.first()
+            val response = apiService.getChatMessages(ChatMessagesRequest(familyId))
+            if (response.isSuccessful && response.body() != null) {
+                val messages = response.body()!!.messages.map { dto ->
+                    ChatMessage(
+                        id = dto.id,
+                        content = dto.content,
+                        createdAt = dto.createdAt,
+                        userId = dto.userId,
+                        userName = dto.userName,
+                        isOwnMessage = dto.userId == currentUserId
+                    )
+                }.reversed()
+                _uiState.update { it.copy(messages = messages, isLoading = false) }
+            } else {
+                _uiState.update { it.copy(isLoading = false) }
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error loading messages")
+            _uiState.update { it.copy(isLoading = false) }
+        }
+    }
+
+    private fun startPolling() {
+        viewModelScope.launch {
+            while (true) {
+                delay(10_000)
+                loadMessages()
+            }
+        }
+    }
+
+    fun updateInput(text: String) {
+        _uiState.update { it.copy(inputText = text) }
+    }
+
+    fun sendMessage() {
+        val text = _uiState.value.inputText.trim()
+        if (text.isBlank()) return
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSending = true, inputText = "") }
+            try {
+                val userId = settingsRepository.userId.first()
+                val response = apiService.sendChatMessage(
+                    ChatSendRequest(fromUserId = userId, content = text)
+                )
+                if (response.isSuccessful) {
+                    loadMessages()
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error sending message")
+            }
+            _uiState.update { it.copy(isSending = false) }
+        }
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/profile/ProfileScreen.kt
@@ -1,0 +1,184 @@
+package com.monghit.familytrack.ui.screens.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: ProfileViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val clipboardManager = LocalClipboardManager.current
+
+    LaunchedEffect(uiState.message) {
+        uiState.message?.let {
+            snackbarHostState.showSnackbar(it)
+            viewModel.clearMessage()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Mi Perfil") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { padding ->
+        if (uiState.isLoading) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Person,
+                    contentDescription = null,
+                    modifier = Modifier.size(80.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                OutlinedTextField(
+                    value = uiState.name,
+                    onValueChange = viewModel::updateName,
+                    label = { Text("Nombre") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                OutlinedTextField(
+                    value = uiState.role.replaceFirstChar { it.uppercase() },
+                    onValueChange = {},
+                    label = { Text("Rol") },
+                    modifier = Modifier.fillMaxWidth(),
+                    readOnly = true,
+                    singleLine = true
+                )
+
+                if (uiState.familyName.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    OutlinedTextField(
+                        value = uiState.familyName,
+                        onValueChange = {},
+                        label = { Text("Familia") },
+                        modifier = Modifier.fillMaxWidth(),
+                        readOnly = true,
+                        singleLine = true
+                    )
+                }
+
+                if (uiState.inviteCode.isNotBlank()) {
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Card(
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text(
+                                text = "Código de invitación",
+                                style = MaterialTheme.typography.labelMedium
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            androidx.compose.foundation.layout.Row(
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = uiState.inviteCode,
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    fontWeight = FontWeight.Bold,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                IconButton(onClick = {
+                                    clipboardManager.setText(AnnotatedString(uiState.inviteCode))
+                                }) {
+                                    Icon(Icons.Filled.ContentCopy, contentDescription = "Copiar")
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Button(
+                    onClick = viewModel::saveProfile,
+                    modifier = Modifier.fillMaxWidth(),
+                    enabled = !uiState.isSaving
+                ) {
+                    if (uiState.isSaving) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text("Guardar cambios")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/profile/ProfileViewModel.kt
@@ -1,0 +1,123 @@
+package com.monghit.familytrack.ui.screens.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.monghit.familytrack.data.remote.ApiService
+import com.monghit.familytrack.data.remote.dto.GetProfileRequest
+import com.monghit.familytrack.data.remote.dto.UpdateProfileRequest
+import com.monghit.familytrack.data.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+data class ProfileUiState(
+    val name: String = "",
+    val role: String = "",
+    val familyName: String = "",
+    val inviteCode: String = "",
+    val avatar: String? = null,
+    val isLoading: Boolean = true,
+    val isSaving: Boolean = false,
+    val message: String? = null
+)
+
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    private val apiService: ApiService,
+    private val settingsRepository: SettingsRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ProfileUiState())
+    val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
+
+    init {
+        loadProfile()
+    }
+
+    private fun loadProfile() {
+        viewModelScope.launch {
+            try {
+                val userId = settingsRepository.userId.first()
+                val response = apiService.getProfile(GetProfileRequest(userId))
+                if (response.isSuccessful && response.body() != null) {
+                    val body = response.body()!!
+                    _uiState.update {
+                        it.copy(
+                            name = body.name,
+                            role = body.role,
+                            familyName = body.familyName ?: "",
+                            inviteCode = body.inviteCode ?: "",
+                            avatar = body.avatar,
+                            isLoading = false
+                        )
+                    }
+                } else {
+                    // Fallback to local data
+                    _uiState.update {
+                        it.copy(
+                            name = settingsRepository.userName.first(),
+                            familyName = settingsRepository.familyName.first(),
+                            inviteCode = settingsRepository.inviteCode.first(),
+                            role = settingsRepository.userRole.first(),
+                            isLoading = false
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error loading profile")
+                _uiState.update {
+                    it.copy(
+                        name = settingsRepository.userName.first(),
+                        isLoading = false
+                    )
+                }
+            }
+        }
+    }
+
+    fun updateName(name: String) {
+        _uiState.update { it.copy(name = name) }
+    }
+
+    fun saveProfile() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSaving = true) }
+            try {
+                val userId = settingsRepository.userId.first()
+                val state = _uiState.value
+                val response = apiService.updateProfile(
+                    UpdateProfileRequest(
+                        userId = userId,
+                        name = state.name,
+                        avatar = state.avatar
+                    )
+                )
+                if (response.isSuccessful) {
+                    settingsRepository.setUserName(state.name)
+                    _uiState.update {
+                        it.copy(isSaving = false, message = "Perfil actualizado")
+                    }
+                } else {
+                    _uiState.update {
+                        it.copy(isSaving = false, message = "Error al guardar")
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error saving profile")
+                _uiState.update {
+                    it.copy(isSaving = false, message = "Error de conexión")
+                }
+            }
+        }
+    }
+
+    fun clearMessage() {
+        _uiState.update { it.copy(message = null) }
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.MyLocation
 import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material3.Button
@@ -51,6 +52,8 @@ import com.monghit.familytrack.R
 
 @Composable
 fun SettingsScreen(
+    onNavigateToProfile: () -> Unit = {},
+    onNavigateToChat: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -150,6 +153,36 @@ fun SettingsScreen(
                     title = stringResource(R.string.settings_device_name),
                     value = uiState.deviceName
                 )
+                HorizontalDivider()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = onNavigateToProfile,
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Person,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 4.dp)
+                        )
+                        Text("Editar perfil")
+                    }
+                    OutlinedButton(
+                        onClick = onNavigateToChat,
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Chat,
+                            contentDescription = null,
+                            modifier = Modifier.padding(end = 4.dp)
+                        )
+                        Text("Chat familiar")
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
## Summary
- Profile editing screen with name, role, family info, invite code display
- Family chat with real-time polling (10s) and message bubbles
- DTOs and API endpoints for all v2 features (#24-#30)
- 9 new n8n workflows activated on server (profile, chat, photos, emergency, location history, quick message)
- PostgreSQL schema: avatar on users, messages table, photos table

## Test plan
- [ ] Open Settings > Edit profile
- [ ] Change name and save
- [ ] Open Settings > Chat familiar
- [ ] Send and receive chat messages
- [ ] Verify polling updates messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)