### PR TITLE
feat(#32): splash screen y onboarding

### DIFF
--- a/app/src/main/java/com/monghit/familytrack/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/repository/SettingsRepository.kt
@@ -36,6 +36,7 @@ class SettingsRepository @Inject constructor(
         val FAMILY_NAME = stringPreferencesKey("family_name")
         val INVITE_CODE = stringPreferencesKey("invite_code")
         val USER_ROLE = stringPreferencesKey("user_role")
+        val ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
     }
 
     val isLocationEnabled: Flow<Boolean> = context.dataStore.data
@@ -106,6 +107,11 @@ class SettingsRepository @Inject constructor(
     val userRole: Flow<String> = context.dataStore.data
         .map { preferences ->
             preferences[PreferencesKeys.USER_ROLE] ?: ""
+        }
+
+    val onboardingCompleted: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.ONBOARDING_COMPLETED] ?: false
         }
 
     suspend fun setLocationEnabled(enabled: Boolean) {
@@ -189,6 +195,12 @@ class SettingsRepository @Inject constructor(
     suspend fun setUserRole(role: String) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.USER_ROLE] = role
+        }
+    }
+
+    suspend fun setOnboardingCompleted(completed: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.ONBOARDING_COMPLETED] = completed
         }
     }
 

--- a/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
@@ -11,4 +11,6 @@ sealed class NavRoutes(val route: String) {
     data object PinLock : NavRoutes("pin_lock")
     data object Profile : NavRoutes("profile")
     data object Chat : NavRoutes("chat")
+    data object Splash : NavRoutes("splash")
+    data object Onboarding : NavRoutes("onboarding")
 }

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/onboarding/OnboardingScreen.kt
@@ -1,0 +1,156 @@
+package com.monghit.familytrack.ui.screens.onboarding
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FamilyRestroom
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+private data class OnboardingPage(
+    val icon: ImageVector,
+    val title: String,
+    val description: String
+)
+
+private val pages = listOf(
+    OnboardingPage(
+        icon = Icons.Filled.FamilyRestroom,
+        title = "Tu familia conectada",
+        description = "Crea o unete a un grupo familiar para compartir la ubicacion en tiempo real con tus seres queridos."
+    ),
+    OnboardingPage(
+        icon = Icons.Filled.LocationOn,
+        title = "Ubicacion en tiempo real",
+        description = "Ve donde estan tus familiares en el mapa, configura zonas seguras y recibe alertas."
+    ),
+    OnboardingPage(
+        icon = Icons.Filled.Shield,
+        title = "Seguridad y privacidad",
+        description = "Tu informacion esta protegida. Controla quien puede ver tu ubicacion y cuando compartes."
+    )
+)
+
+@Composable
+fun OnboardingScreen(
+    onOnboardingComplete: () -> Unit
+) {
+    var currentPage by remember { mutableIntStateOf(0) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        // Skip button
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
+        ) {
+            if (currentPage < pages.size - 1) {
+                TextButton(onClick = onOnboardingComplete) {
+                    Text("Saltar")
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        // Content
+        AnimatedContent(
+            targetState = currentPage,
+            label = "onboarding_page"
+        ) { page ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Icon(
+                    imageVector = pages[page].icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(120.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.height(32.dp))
+                Text(
+                    text = pages[page].title,
+                    style = MaterialTheme.typography.headlineMedium,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = pages[page].description,
+                    style = MaterialTheme.typography.bodyLarge,
+                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        // Page indicators
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier.padding(bottom = 24.dp)
+        ) {
+            repeat(pages.size) { index ->
+                Box(
+                    modifier = Modifier
+                        .size(if (index == currentPage) 12.dp else 8.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (index == currentPage) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.outlineVariant
+                        )
+                )
+            }
+        }
+
+        // Button
+        Button(
+            onClick = {
+                if (currentPage < pages.size - 1) {
+                    currentPage++
+                } else {
+                    onOnboardingComplete()
+                }
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = if (currentPage < pages.size - 1) "Siguiente" else "Comenzar"
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/splash/SplashScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/splash/SplashScreen.kt
@@ -1,0 +1,78 @@
+package com.monghit.familytrack.ui.screens.splash
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FamilyRestroom
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+@Composable
+fun SplashScreen(
+    onSplashFinished: () -> Unit
+) {
+    var startAnimation by remember { mutableStateOf(false) }
+    val alpha by animateFloatAsState(
+        targetValue = if (startAnimation) 1f else 0f,
+        animationSpec = tween(durationMillis = 800),
+        label = "splash_alpha"
+    )
+
+    LaunchedEffect(Unit) {
+        startAnimation = true
+        delay(1500)
+        onSplashFinished()
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.primary),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Filled.FamilyRestroom,
+            contentDescription = null,
+            modifier = Modifier
+                .size(120.dp)
+                .alpha(alpha),
+            tint = MaterialTheme.colorScheme.onPrimary
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            text = "FamilyTrack",
+            style = MaterialTheme.typography.headlineLarge,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onPrimary,
+            modifier = Modifier.alpha(alpha)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "Tu familia, siempre conectada",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onPrimary.copy(alpha = 0.8f),
+            modifier = Modifier.alpha(alpha)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Splash screen with animated logo and tagline (1.5s)
- 3-step onboarding: family connection, real-time location, privacy
- Navigation flow: Splash -> Onboarding (first time) -> FamilySetup -> Home
- Onboarding preference persisted in DataStore

## Test plan
- [ ] First launch shows splash then onboarding
- [ ] Subsequent launches skip onboarding
- [ ] Skip button works on onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)