### PR TITLE
feat(#29): historial de rutas con mapa

### DIFF
--- a/app/src/main/java/com/monghit/familytrack/ui/navigation/FamilyTrackNavHost.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/navigation/FamilyTrackNavHost.kt
@@ -42,6 +42,7 @@ import com.monghit.familytrack.ui.screens.onboarding.OnboardingScreen
 import com.monghit.familytrack.ui.screens.permissions.PermissionsScreen
 import com.monghit.familytrack.ui.screens.photos.PhotosScreen
 import com.monghit.familytrack.ui.screens.profile.ProfileScreen
+import com.monghit.familytrack.ui.screens.routehistory.RouteHistoryScreen
 import com.monghit.familytrack.ui.screens.splash.SplashScreen
 import com.monghit.familytrack.ui.screens.safezones.SafeZonesScreen
 import com.monghit.familytrack.ui.screens.settings.SettingsScreen
@@ -231,6 +232,11 @@ fun FamilyTrackNavHost(
             }
             composable(NavRoutes.Photos.route) {
                 PhotosScreen(
+                    onNavigateBack = { navController.popBackStack() }
+                )
+            }
+            composable(NavRoutes.RouteHistory.route) {
+                RouteHistoryScreen(
                     onNavigateBack = { navController.popBackStack() }
                 )
             }

--- a/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/navigation/NavRoutes.kt
@@ -14,4 +14,5 @@ sealed class NavRoutes(val route: String) {
     data object Splash : NavRoutes("splash")
     data object Onboarding : NavRoutes("onboarding")
     data object Photos : NavRoutes("photos")
+    data object RouteHistory : NavRoutes("route_history")
 }

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/routehistory/RouteHistoryScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/routehistory/RouteHistoryScreen.kt
@@ -1,0 +1,158 @@
+package com.monghit.familytrack.ui.screens.routehistory
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.Polyline
+import com.google.maps.android.compose.rememberCameraPositionState
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RouteHistoryScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: RouteHistoryViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+    val displayFormat = SimpleDateFormat("dd MMM yyyy", Locale("es"))
+
+    val displayDate = try {
+        val date = dateFormat.parse(uiState.selectedDate)
+        if (date != null) displayFormat.format(date) else uiState.selectedDate
+    } catch (_: Exception) {
+        uiState.selectedDate
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Historial de rutas") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            // Date selector
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = {
+                    val cal = Calendar.getInstance()
+                    cal.time = dateFormat.parse(uiState.selectedDate) ?: cal.time
+                    cal.add(Calendar.DAY_OF_MONTH, -1)
+                    viewModel.selectDate(dateFormat.format(cal.time))
+                }) {
+                    Icon(Icons.Filled.ChevronLeft, contentDescription = "Dia anterior")
+                }
+                Text(
+                    text = displayDate,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                )
+                IconButton(onClick = {
+                    val cal = Calendar.getInstance()
+                    cal.time = dateFormat.parse(uiState.selectedDate) ?: cal.time
+                    cal.add(Calendar.DAY_OF_MONTH, 1)
+                    if (!cal.time.after(Calendar.getInstance().time)) {
+                        viewModel.selectDate(dateFormat.format(cal.time))
+                    }
+                }) {
+                    Icon(Icons.Filled.ChevronRight, contentDescription = "Dia siguiente")
+                }
+            }
+
+            if (uiState.isLoading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else if (uiState.points.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        "No hay datos de ruta para este dia",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            } else {
+                val points = uiState.points.map { LatLng(it.latitude, it.longitude) }
+                val center = points.first()
+                val cameraPositionState = rememberCameraPositionState {
+                    position = CameraPosition.fromLatLngZoom(center, 14f)
+                }
+
+                Text(
+                    text = "${uiState.points.size} puntos registrados",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                GoogleMap(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    cameraPositionState = cameraPositionState
+                ) {
+                    Polyline(
+                        points = points,
+                        color = androidx.compose.ui.graphics.Color(0xFF1976D2),
+                        width = 8f
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/routehistory/RouteHistoryViewModel.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/routehistory/RouteHistoryViewModel.kt
@@ -1,0 +1,77 @@
+package com.monghit.familytrack.ui.screens.routehistory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.monghit.familytrack.data.remote.ApiService
+import com.monghit.familytrack.data.repository.SettingsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+data class RoutePoint(
+    val latitude: Double,
+    val longitude: Double,
+    val accuracy: Float?,
+    val timestamp: String?
+)
+
+data class RouteHistoryUiState(
+    val points: List<RoutePoint> = emptyList(),
+    val selectedDate: String = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date()),
+    val isLoading: Boolean = false
+)
+
+@HiltViewModel
+class RouteHistoryViewModel @Inject constructor(
+    private val apiService: ApiService,
+    private val settingsRepository: SettingsRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RouteHistoryUiState())
+    val uiState: StateFlow<RouteHistoryUiState> = _uiState.asStateFlow()
+
+    init {
+        loadHistory()
+    }
+
+    fun selectDate(date: String) {
+        _uiState.update { it.copy(selectedDate = date) }
+        loadHistory()
+    }
+
+    private fun loadHistory() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                val userId = settingsRepository.userId.first()
+                val date = _uiState.value.selectedDate
+                val response = apiService.getLocationHistory(userId, date)
+                if (response.isSuccessful && response.body() != null) {
+                    val points = response.body()!!.locations.map { dto ->
+                        RoutePoint(
+                            latitude = dto.latitude,
+                            longitude = dto.longitude,
+                            accuracy = dto.accuracy,
+                            timestamp = dto.timestamp
+                        )
+                    }
+                    _uiState.update { it.copy(points = points, isLoading = false) }
+                } else {
+                    _uiState.update { it.copy(points = emptyList(), isLoading = false) }
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error loading route history")
+                _uiState.update { it.copy(points = emptyList(), isLoading = false) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add RouteHistoryScreen with Google Maps polyline visualization
- Add RouteHistoryViewModel with date-based location history loading
- Add date selector (prev/next day navigation)
- Integrate route history into navigation graph

## Test plan
- [ ] Verify route history screen loads from home navigation
- [ ] Verify date selector works (prev/next day, can't go past today)
- [ ] Verify polyline renders on map with location data

🤖 Generated with [Claude Code](https://claude.com/claude-code)