### PR TITLE
feat(#30): alerta batería baja

### DIFF
--- a/app/src/main/java/com/monghit/familytrack/data/remote/dto/ApiDtos.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/remote/dto/ApiDtos.kt
@@ -23,7 +23,9 @@ data class LocationUpdateRequest(
     @SerializedName("latitude") val latitude: Double,
     @SerializedName("longitude") val longitude: Double,
     @SerializedName("accuracy") val accuracy: Float,
-    @SerializedName("timestamp") val timestamp: Long
+    @SerializedName("timestamp") val timestamp: Long,
+    @SerializedName("batteryLevel") val batteryLevel: Int? = null,
+    @SerializedName("isCharging") val isCharging: Boolean? = null
 )
 
 data class LocationUpdateResponse(
@@ -79,7 +81,9 @@ data class FamilyMemberDto(
     @SerializedName("deviceName") val deviceName: String?,
     @SerializedName("isOnline") val isOnline: Boolean,
     @SerializedName("lastSeenFormatted") val lastSeenFormatted: String,
-    @SerializedName("location") val location: LocationDto?
+    @SerializedName("location") val location: LocationDto?,
+    @SerializedName("batteryLevel") val batteryLevel: Int? = null,
+    @SerializedName("isCharging") val isCharging: Boolean? = null
 )
 
 data class LocationDto(

--- a/app/src/main/java/com/monghit/familytrack/data/repository/LocationRepository.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/repository/LocationRepository.kt
@@ -50,7 +50,11 @@ class LocationRepository @Inject constructor(
         }
     }
 
-    suspend fun sendLocation(location: Location): Result<Boolean> {
+    suspend fun sendLocation(
+        location: Location,
+        batteryLevel: Int = -1,
+        isCharging: Boolean = false
+    ): Result<Boolean> {
         return try {
             val deviceToken = settingsRepository.deviceToken.first()
             val userId = settingsRepository.userId.first()
@@ -61,7 +65,9 @@ class LocationRepository @Inject constructor(
                 latitude = location.latitude,
                 longitude = location.longitude,
                 accuracy = location.accuracy,
-                timestamp = location.timestamp
+                timestamp = location.timestamp,
+                batteryLevel = if (batteryLevel >= 0) batteryLevel else null,
+                isCharging = if (batteryLevel >= 0) isCharging else null
             )
 
             val response = apiService.updateLocation(request)
@@ -120,7 +126,9 @@ class LocationRepository @Inject constructor(
                                 timestamp = System.currentTimeMillis()
                             )
                         } else null,
-                        isOnline = dto.isOnline
+                        isOnline = dto.isOnline,
+                        batteryLevel = dto.batteryLevel,
+                        isCharging = dto.isCharging
                     )
                 }
                 val safeZones = body.safeZones.map { dto ->

--- a/app/src/main/java/com/monghit/familytrack/domain/model/FamilyMember.kt
+++ b/app/src/main/java/com/monghit/familytrack/domain/model/FamilyMember.kt
@@ -4,7 +4,9 @@ data class FamilyMember(
     val user: User,
     val device: Device?,
     val lastLocation: Location?,
-    val isOnline: Boolean
+    val isOnline: Boolean,
+    val batteryLevel: Int? = null,
+    val isCharging: Boolean? = null
 ) {
     val displayName: String get() = user.name
     val lastSeenFormatted: String get() = formatLastSeen(device?.lastSeen)

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/family/FamilyScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/family/FamilyScreen.kt
@@ -15,6 +15,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BatteryAlert
+import androidx.compose.material.icons.filled.BatteryChargingFull
+import androidx.compose.material.icons.filled.BatteryFull
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Notifications
@@ -192,6 +195,33 @@ private fun FamilyMemberCard(
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.primary
                 )
+
+                if (member.batteryLevel != null) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        val batteryIcon = when {
+                            member.isCharging == true -> Icons.Default.BatteryChargingFull
+                            member.batteryLevel <= 15 -> Icons.Default.BatteryAlert
+                            else -> Icons.Default.BatteryFull
+                        }
+                        val batteryColor = when {
+                            member.batteryLevel <= 15 -> Error
+                            member.batteryLevel <= 30 -> MaterialTheme.colorScheme.tertiary
+                            else -> Success
+                        }
+                        Icon(
+                            imageVector = batteryIcon,
+                            contentDescription = null,
+                            modifier = Modifier.size(14.dp),
+                            tint = batteryColor
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = "${member.batteryLevel}%",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = batteryColor
+                        )
+                    }
+                }
 
                 Spacer(modifier = Modifier.height(2.dp))
 


### PR DESCRIPTION
## Summary
- Read battery level and charging status in LocationForegroundService
- Send battery data with each location update to backend
- Display battery indicator with color-coded icon in FamilyScreen member cards
- Battery colors: red (<=15%), yellow (<=30%), green (>30%)

## Test plan
- [ ] Verify battery percentage shown on family member cards
- [ ] Verify battery icon changes based on level and charging state
- [ ] Verify location updates include batteryLevel and isCharging fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)