### PR TITLE
feat(#31): modo oscuro

### DIFF
--- a/app/src/main/java/com/monghit/familytrack/MainActivity.kt
+++ b/app/src/main/java/com/monghit/familytrack/MainActivity.kt
@@ -4,9 +4,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.monghit.familytrack.data.repository.SecurityRepository
 import com.monghit.familytrack.data.repository.SettingsRepository
@@ -29,7 +32,13 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         setContent {
-            FamilyTrackTheme {
+            val darkModePreference by settingsRepository.darkMode.collectAsState(initial = "system")
+            val darkTheme = when (darkModePreference) {
+                "dark" -> true
+                "light" -> false
+                else -> isSystemInDarkTheme()
+            }
+            FamilyTrackTheme(darkTheme = darkTheme) {
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background

--- a/app/src/main/java/com/monghit/familytrack/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/monghit/familytrack/data/repository/SettingsRepository.kt
@@ -37,6 +37,7 @@ class SettingsRepository @Inject constructor(
         val INVITE_CODE = stringPreferencesKey("invite_code")
         val USER_ROLE = stringPreferencesKey("user_role")
         val ONBOARDING_COMPLETED = booleanPreferencesKey("onboarding_completed")
+        val DARK_MODE = stringPreferencesKey("dark_mode")
     }
 
     val isLocationEnabled: Flow<Boolean> = context.dataStore.data
@@ -112,6 +113,11 @@ class SettingsRepository @Inject constructor(
     val onboardingCompleted: Flow<Boolean> = context.dataStore.data
         .map { preferences ->
             preferences[PreferencesKeys.ONBOARDING_COMPLETED] ?: false
+        }
+
+    val darkMode: Flow<String> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferencesKeys.DARK_MODE] ?: "system"
         }
 
     suspend fun setLocationEnabled(enabled: Boolean) {
@@ -201,6 +207,12 @@ class SettingsRepository @Inject constructor(
     suspend fun setOnboardingCompleted(completed: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.ONBOARDING_COMPLETED] = completed
+        }
+    }
+
+    suspend fun setDarkMode(mode: String) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.DARK_MODE] = mode
         }
     }
 

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.Brightness6
 import androidx.compose.material.icons.filled.Build
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Info
@@ -109,6 +110,44 @@ fun SettingsScreen(
                     checked = uiState.notificationsEnabled,
                     onCheckedChange = viewModel::toggleNotifications
                 )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Appearance Section
+            SettingsSection(
+                title = "Apariencia",
+                icon = Icons.Default.Brightness6
+            ) {
+                Text(
+                    text = "Tema",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                val options = listOf("system" to "Sistema", "light" to "Claro", "dark" to "Oscuro")
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
+                ) {
+                    options.forEach { (value, label) ->
+                        val selected = uiState.darkMode == value
+                        if (selected) {
+                            Button(
+                                onClick = {},
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(label)
+                            }
+                        } else {
+                            OutlinedButton(
+                                onClick = { viewModel.setDarkMode(value) },
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(label)
+                            }
+                        }
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsViewModel.kt
@@ -30,7 +30,8 @@ data class SettingsUiState(
     val lastLocationUpdate: String = "Nunca",
     val actionMessage: String? = null,
     val isPinSet: Boolean = false,
-    val isBiometricEnabled: Boolean = false
+    val isBiometricEnabled: Boolean = false,
+    val darkMode: String = "system"
 )
 
 @HiltViewModel
@@ -104,6 +105,11 @@ class SettingsViewModel @Inject constructor(
                 _uiState.update { it.copy(lastLocationUpdate = formatted) }
             }
         }
+        viewModelScope.launch {
+            settingsRepository.darkMode.collect { mode ->
+                _uiState.update { it.copy(darkMode = mode) }
+            }
+        }
     }
 
     private fun loadSecuritySettings() {
@@ -156,6 +162,12 @@ class SettingsViewModel @Inject constructor(
     fun toggleNotifications(enabled: Boolean) {
         viewModelScope.launch {
             settingsRepository.setNotificationsEnabled(enabled)
+        }
+    }
+
+    fun setDarkMode(mode: String) {
+        viewModelScope.launch {
+            settingsRepository.setDarkMode(mode)
         }
     }
 


### PR DESCRIPTION
## Summary
- Add dark mode preference (system/light/dark) to DataStore
- Wire preference from MainActivity to FamilyTrackTheme
- Add appearance section in SettingsScreen with theme toggle buttons

## Test plan
- [ ] Verify dark mode switches immediately when selecting "Oscuro"
- [ ] Verify light mode works with "Claro" option
- [ ] Verify "Sistema" follows device dark mode setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)