### PR TITLE
feat(#33): i18n español/inglés

### DIFF
--- a/app/src/main/java/com/monghit/familytrack/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/home/HomeScreen.kt
@@ -107,8 +107,8 @@ fun HomeScreen(
     if (showSosDialog) {
         AlertDialog(
             onDismissRequest = { showSosDialog = false },
-            title = { Text("Enviar SOS") },
-            text = { Text("Se enviara una alerta de emergencia a todos los miembros de tu familia. Continuar?") },
+            title = { Text(stringResource(R.string.home_sos_title)) },
+            text = { Text(stringResource(R.string.home_sos_confirm)) },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -117,12 +117,12 @@ fun HomeScreen(
                     },
                     enabled = !uiState.isSendingSos
                 ) {
-                    Text("Enviar SOS", color = MaterialTheme.colorScheme.error)
+                    Text(stringResource(R.string.home_sos_send), color = MaterialTheme.colorScheme.error)
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showSosDialog = false }) {
-                    Text("Cancelar")
+                    Text(stringResource(R.string.cancel))
                 }
             }
         )
@@ -316,16 +316,16 @@ private fun IntervalSlider(
 @Composable
 private fun QuickMessages(onSend: (String) -> Unit) {
     val messages = listOf(
-        "Estoy bien",
-        "Voy para casa",
-        "Estoy llegando",
-        "Llamame",
-        "Voy a tardar"
+        stringResource(R.string.quick_msg_im_fine),
+        stringResource(R.string.quick_msg_going_home),
+        stringResource(R.string.quick_msg_arriving),
+        stringResource(R.string.quick_msg_call_me),
+        stringResource(R.string.quick_msg_will_be_late)
     )
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                text = "Mensajes rapidos",
+                text = stringResource(R.string.home_quick_messages),
                 style = MaterialTheme.typography.titleSmall,
                 modifier = Modifier.padding(bottom = 8.dp)
             )

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/onboarding/OnboardingScreen.kt
@@ -31,9 +31,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.monghit.familytrack.R
 
 private data class OnboardingPage(
     val icon: ImageVector,
@@ -41,29 +43,29 @@ private data class OnboardingPage(
     val description: String
 )
 
-private val pages = listOf(
-    OnboardingPage(
-        icon = Icons.Filled.FamilyRestroom,
-        title = "Tu familia conectada",
-        description = "Crea o unete a un grupo familiar para compartir la ubicacion en tiempo real con tus seres queridos."
-    ),
-    OnboardingPage(
-        icon = Icons.Filled.LocationOn,
-        title = "Ubicacion en tiempo real",
-        description = "Ve donde estan tus familiares en el mapa, configura zonas seguras y recibe alertas."
-    ),
-    OnboardingPage(
-        icon = Icons.Filled.Shield,
-        title = "Seguridad y privacidad",
-        description = "Tu informacion esta protegida. Controla quien puede ver tu ubicacion y cuando compartes."
-    )
-)
-
 @Composable
 fun OnboardingScreen(
     onOnboardingComplete: () -> Unit
 ) {
     var currentPage by remember { mutableIntStateOf(0) }
+
+    val pages = listOf(
+        OnboardingPage(
+            icon = Icons.Filled.FamilyRestroom,
+            title = stringResource(R.string.onboarding_title_1),
+            description = stringResource(R.string.onboarding_desc_1)
+        ),
+        OnboardingPage(
+            icon = Icons.Filled.LocationOn,
+            title = stringResource(R.string.onboarding_title_2),
+            description = stringResource(R.string.onboarding_desc_2)
+        ),
+        OnboardingPage(
+            icon = Icons.Filled.Shield,
+            title = stringResource(R.string.onboarding_title_3),
+            description = stringResource(R.string.onboarding_desc_3)
+        )
+    )
 
     Column(
         modifier = Modifier
@@ -78,7 +80,7 @@ fun OnboardingScreen(
         ) {
             if (currentPage < pages.size - 1) {
                 TextButton(onClick = onOnboardingComplete) {
-                    Text("Saltar")
+                    Text(stringResource(R.string.onboarding_skip))
                 }
             }
         }
@@ -149,7 +151,7 @@ fun OnboardingScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text(
-                text = if (currentPage < pages.size - 1) "Siguiente" else "Comenzar"
+                text = if (currentPage < pages.size - 1) stringResource(R.string.onboarding_next) else stringResource(R.string.onboarding_start)
             )
         }
     }

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/routehistory/RouteHistoryScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/routehistory/RouteHistoryScreen.kt
@@ -32,6 +32,8 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.Polyline
 import com.google.maps.android.compose.rememberCameraPositionState
+import androidx.compose.ui.res.stringResource
+import com.monghit.familytrack.R
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -56,10 +58,10 @@ fun RouteHistoryScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Historial de rutas") },
+                title = { Text(stringResource(R.string.route_history_title)) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Volver")
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.action_back))
                     }
                 }
             )
@@ -83,7 +85,7 @@ fun RouteHistoryScreen(
                     cal.add(Calendar.DAY_OF_MONTH, -1)
                     viewModel.selectDate(dateFormat.format(cal.time))
                 }) {
-                    Icon(Icons.Filled.ChevronLeft, contentDescription = "Dia anterior")
+                    Icon(Icons.Filled.ChevronLeft, contentDescription = stringResource(R.string.route_history_prev_day))
                 }
                 Text(
                     text = displayDate,
@@ -99,7 +101,7 @@ fun RouteHistoryScreen(
                         viewModel.selectDate(dateFormat.format(cal.time))
                     }
                 }) {
-                    Icon(Icons.Filled.ChevronRight, contentDescription = "Dia siguiente")
+                    Icon(Icons.Filled.ChevronRight, contentDescription = stringResource(R.string.route_history_next_day))
                 }
             }
 
@@ -120,7 +122,7 @@ fun RouteHistoryScreen(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        "No hay datos de ruta para este dia",
+                        stringResource(R.string.route_history_empty),
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
@@ -132,7 +134,7 @@ fun RouteHistoryScreen(
                 }
 
                 Text(
-                    text = "${uiState.points.size} puntos registrados",
+                    text = stringResource(R.string.route_history_points, uiState.points.size),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(horizontal = 16.dp)

--- a/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/monghit/familytrack/ui/screens/settings/SettingsScreen.kt
@@ -116,15 +116,19 @@ fun SettingsScreen(
 
             // Appearance Section
             SettingsSection(
-                title = "Apariencia",
+                title = stringResource(R.string.settings_appearance),
                 icon = Icons.Default.Brightness6
             ) {
                 Text(
-                    text = "Tema",
+                    text = stringResource(R.string.settings_theme),
                     style = MaterialTheme.typography.bodyLarge,
                     modifier = Modifier.padding(bottom = 8.dp)
                 )
-                val options = listOf("system" to "Sistema", "light" to "Claro", "dark" to "Oscuro")
+                val options = listOf(
+                    "system" to stringResource(R.string.settings_theme_system),
+                    "light" to stringResource(R.string.settings_theme_light),
+                    "dark" to stringResource(R.string.settings_theme_dark)
+                )
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp)
@@ -154,11 +158,11 @@ fun SettingsScreen(
 
             // Security Section
             SettingsSection(
-                title = "Seguridad",
+                title = stringResource(R.string.settings_security),
                 icon = Icons.Default.Lock
             ) {
                 SettingsSwitchItem(
-                    title = "Bloqueo con PIN",
+                    title = stringResource(R.string.settings_pin_lock),
                     checked = uiState.isPinSet,
                     onCheckedChange = { enabled ->
                         if (!enabled) {
@@ -170,7 +174,7 @@ fun SettingsScreen(
                 if (uiState.isPinSet) {
                     HorizontalDivider()
                     SettingsSwitchItem(
-                        title = "Desbloqueo biométrico",
+                        title = stringResource(R.string.settings_biometric),
                         checked = uiState.isBiometricEnabled,
                         onCheckedChange = viewModel::toggleBiometric
                     )
@@ -185,7 +189,7 @@ fun SettingsScreen(
                         onClick = onNavigateToPermissions,
                         modifier = Modifier.fillMaxWidth()
                     ) {
-                        Text("Gestionar permisos")
+                        Text(stringResource(R.string.settings_manage_permissions))
                     }
                 }
             }
@@ -222,7 +226,7 @@ fun SettingsScreen(
                             contentDescription = null,
                             modifier = Modifier.padding(end = 4.dp)
                         )
-                        Text("Editar perfil")
+                        Text(stringResource(R.string.settings_edit_profile))
                     }
                     OutlinedButton(
                         onClick = onNavigateToChat,
@@ -233,7 +237,7 @@ fun SettingsScreen(
                             contentDescription = null,
                             modifier = Modifier.padding(end = 4.dp)
                         )
-                        Text("Chat familiar")
+                        Text(stringResource(R.string.settings_family_chat))
                     }
                 }
             }
@@ -256,7 +260,7 @@ fun SettingsScreen(
                 )
                 HorizontalDivider()
                 SettingsTextItem(
-                    title = stringResource(R.string.settings_registered, if (uiState.isRegistered) "S\u00ed" else "No"),
+                    title = stringResource(R.string.settings_registered, if (uiState.isRegistered) stringResource(R.string.settings_yes) else stringResource(R.string.settings_no)),
                     value = ""
                 )
                 HorizontalDivider()

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">FamilyTrack</string>
+
+    <!-- Navigation -->
+    <string name="nav_home">Inicio</string>
+    <string name="nav_map">Mapa</string>
+    <string name="nav_family">Familia</string>
+    <string name="nav_settings">Ajustes</string>
+
+    <!-- Home Screen -->
+    <string name="home_title">Mi Ubicación</string>
+    <string name="home_status_active">Activo</string>
+    <string name="home_status_inactive">Inactivo</string>
+    <string name="home_sharing_location">Compartiendo ubicación</string>
+    <string name="home_not_sharing">Ubicación pausada</string>
+    <string name="home_last_update">Última actualización: %1$s</string>
+    <string name="home_interval">Intervalo: %1$d min</string>
+    <string name="home_quick_messages">Mensajes rápidos</string>
+    <string name="home_sos_title">Enviar SOS</string>
+    <string name="home_sos_confirm">Se enviará una alerta de emergencia a todos los miembros de tu familia. ¿Continuar?</string>
+    <string name="home_sos_send">Enviar SOS</string>
+    <string name="home_sos_sent">SOS enviado a tu familia</string>
+    <string name="home_sos_error">Error al enviar SOS</string>
+    <string name="home_message_sent">Mensaje enviado</string>
+    <string name="home_message_error">Error al enviar mensaje</string>
+
+    <!-- Quick Messages -->
+    <string name="quick_msg_im_fine">Estoy bien</string>
+    <string name="quick_msg_going_home">Voy para casa</string>
+    <string name="quick_msg_arriving">Estoy llegando</string>
+    <string name="quick_msg_call_me">Llámame</string>
+    <string name="quick_msg_will_be_late">Voy a tardar</string>
+
+    <!-- Map Screen -->
+    <string name="map_title">Mapa Familiar</string>
+    <string name="map_loading">Cargando ubicaciones…</string>
+    <string name="map_no_locations">Sin ubicaciones disponibles</string>
+
+    <!-- Family Screen -->
+    <string name="family_title">Mi Familia</string>
+    <string name="family_member_online">En línea</string>
+    <string name="family_member_offline">Sin conexión</string>
+    <string name="family_member_last_seen">Visto: %1$s</string>
+    <string name="family_add_member">Añadir miembro</string>
+    <string name="family_empty">No hay miembros registrados</string>
+    <string name="family_notify_sent">Notificación enviada a %1$s</string>
+    <string name="family_role_admin">Admin</string>
+    <string name="family_role_monitor">Monitor</string>
+    <string name="family_role_monitored">Monitoreado</string>
+    <string name="family_notify">Notificar</string>
+
+    <!-- Settings Screen -->
+    <string name="settings_title">Ajustes</string>
+    <string name="settings_location">Ubicación</string>
+    <string name="settings_location_enabled">Compartir ubicación</string>
+    <string name="settings_location_interval">Intervalo de actualización</string>
+    <string name="settings_notifications">Notificaciones</string>
+    <string name="settings_notifications_enabled">Recibir alertas</string>
+    <string name="settings_notifications_sound">Sonido</string>
+    <string name="settings_notifications_vibrate">Vibración</string>
+    <string name="settings_appearance">Apariencia</string>
+    <string name="settings_theme">Tema</string>
+    <string name="settings_theme_system">Sistema</string>
+    <string name="settings_theme_light">Claro</string>
+    <string name="settings_theme_dark">Oscuro</string>
+    <string name="settings_security">Seguridad</string>
+    <string name="settings_pin_lock">Bloqueo con PIN</string>
+    <string name="settings_biometric">Desbloqueo biométrico</string>
+    <string name="settings_manage_permissions">Gestionar permisos</string>
+    <string name="settings_account">Cuenta</string>
+    <string name="settings_device_name">Nombre del dispositivo</string>
+    <string name="settings_user_name">Tu nombre</string>
+    <string name="settings_edit_profile">Editar perfil</string>
+    <string name="settings_family_chat">Chat familiar</string>
+    <string name="settings_logout">Cerrar sesión</string>
+    <string name="settings_about">Acerca de</string>
+    <string name="settings_version">Versión %1$s</string>
+    <string name="settings_interval_value">%1$d min</string>
+    <string name="settings_device_info">Dispositivo</string>
+    <string name="settings_device_id">ID dispositivo: %1$d</string>
+    <string name="settings_user_id">ID usuario: %1$d</string>
+    <string name="settings_registered">Registrado: %1$s</string>
+    <string name="settings_last_update">Última ubicación: %1$s</string>
+    <string name="settings_token">Token FCM</string>
+    <string name="settings_actions">Acciones</string>
+    <string name="settings_send_location_now">Enviar ubicación ahora</string>
+    <string name="settings_test_notification">Probar notificación</string>
+    <string name="settings_yes">Sí</string>
+    <string name="settings_no">No</string>
+    <string name="settings_never">Nunca</string>
+
+    <!-- Profile -->
+    <string name="profile_title">Mi Perfil</string>
+    <string name="profile_name">Nombre</string>
+    <string name="profile_role">Rol</string>
+    <string name="profile_family">Familia</string>
+    <string name="profile_invite_code">Código de invitación</string>
+    <string name="profile_save">Guardar</string>
+    <string name="profile_saved">Perfil guardado</string>
+    <string name="profile_copy">Copiar</string>
+
+    <!-- Chat -->
+    <string name="chat_title">Chat Familiar</string>
+    <string name="chat_send">Enviar</string>
+    <string name="chat_hint">Escribe un mensaje…</string>
+    <string name="chat_empty">No hay mensajes aún</string>
+
+    <!-- Photos -->
+    <string name="photos_title">Fotos</string>
+    <string name="photos_empty">No hay fotos</string>
+    <string name="photos_sent">Foto enviada</string>
+    <string name="photos_send_error">Error al enviar foto</string>
+
+    <!-- Route History -->
+    <string name="route_history_title">Historial de rutas</string>
+    <string name="route_history_prev_day">Día anterior</string>
+    <string name="route_history_next_day">Día siguiente</string>
+    <string name="route_history_points">%1$d puntos registrados</string>
+    <string name="route_history_empty">No hay datos de ruta para este día</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_skip">Saltar</string>
+    <string name="onboarding_next">Siguiente</string>
+    <string name="onboarding_start">Comenzar</string>
+    <string name="onboarding_title_1">Tu familia, siempre cerca</string>
+    <string name="onboarding_desc_1">Mantén a tu familia conectada y segura en todo momento</string>
+    <string name="onboarding_title_2">Ubicación en tiempo real</string>
+    <string name="onboarding_desc_2">Comparte tu ubicación y conoce dónde están tus seres queridos</string>
+    <string name="onboarding_title_3">Privacidad garantizada</string>
+    <string name="onboarding_desc_3">Solo tu familia puede ver tu ubicación. Tus datos están protegidos</string>
+
+    <!-- Family Setup -->
+    <string name="family_setup_title">Configura tu familia</string>
+    <string name="family_setup_create">Crear familia</string>
+    <string name="family_setup_join">Unirme a una familia</string>
+    <string name="family_setup_create_title">Crear nueva familia</string>
+    <string name="family_setup_join_title">Unirme a familia</string>
+    <string name="family_setup_family_name">Nombre de la familia</string>
+    <string name="family_setup_your_name">Tu nombre</string>
+    <string name="family_setup_invite_code">Código de invitación</string>
+    <string name="family_setup_admin_note">Serás el administrador de tu familia</string>
+    <string name="family_setup_create_btn">Crear familia</string>
+    <string name="family_setup_join_btn">Unirme</string>
+    <string name="family_setup_success_title">¡Familia creada!</string>
+    <string name="family_setup_share_code">Comparte este código con tu familia:</string>
+    <string name="family_setup_continue">Continuar</string>
+
+    <!-- Permissions -->
+    <string name="permissions_title">Permisos</string>
+    <string name="permissions_location">Ubicación</string>
+    <string name="permissions_notifications">Notificaciones</string>
+    <string name="permissions_background_location">Ubicación en segundo plano</string>
+    <string name="permissions_battery_optimization">Optimización de batería</string>
+    <string name="permissions_granted">Concedido</string>
+    <string name="permissions_denied">Denegado</string>
+    <string name="permissions_grant">Conceder</string>
+    <string name="permissions_open_settings">Abrir ajustes</string>
+    <string name="permissions_continue">Continuar</string>
+
+    <!-- PIN -->
+    <string name="pin_title">Bloqueo PIN</string>
+    <string name="pin_enter">Introduce tu PIN</string>
+    <string name="pin_create">Crea un PIN de 4 dígitos</string>
+    <string name="pin_confirm">Confirma tu PIN</string>
+    <string name="pin_mismatch">Los PINs no coinciden. Inténtalo de nuevo.</string>
+    <string name="pin_biometric">Biometría</string>
+    <string name="pin_delete">Borrar</string>
+
+    <!-- Safe Zones -->
+    <string name="safe_zones_title">Zonas Seguras</string>
+    <string name="safe_zones_empty">No hay zonas seguras configuradas</string>
+    <string name="safe_zone_add">Añadir zona</string>
+    <string name="safe_zone_name">Nombre de la zona</string>
+    <string name="safe_zone_lat">Latitud</string>
+    <string name="safe_zone_lng">Longitud</string>
+    <string name="safe_zone_radius">Radio (metros)</string>
+    <string name="safe_zone_radius_value">%1$d m</string>
+    <string name="safe_zone_delete">Eliminar zona</string>
+    <string name="safe_zone_delete_confirm">¿Eliminar la zona \"%1$s\"?</string>
+
+    <!-- Alerts -->
+    <string name="alert_zone_exit_title">Salida de zona segura</string>
+    <string name="alert_zone_exit_body">%1$s ha salido de %2$s</string>
+    <string name="alert_zone_entry_title">Entrada a zona segura</string>
+    <string name="alert_zone_entry_body">%1$s ha llegado a %2$s</string>
+    <string name="alert_offline_title">Dispositivo sin conexión</string>
+    <string name="alert_offline_body">%1$s no ha reportado ubicación en las últimas 24 horas</string>
+
+    <!-- Permissions Dialog -->
+    <string name="permission_location_title">Permiso de ubicación</string>
+    <string name="permission_location_rationale">FamilyTrack necesita acceso a tu ubicación para compartirla con tu familia.</string>
+    <string name="permission_location_background_title">Ubicación en segundo plano</string>
+    <string name="permission_location_background_rationale">Para compartir tu ubicación incluso cuando la app está cerrada, necesitamos permiso de ubicación en segundo plano.</string>
+    <string name="permission_notification_title">Permiso de notificaciones</string>
+    <string name="permission_notification_rationale">Necesitamos permiso para enviarte alertas importantes sobre tu familia.</string>
+    <string name="permission_grant">Conceder</string>
+    <string name="permission_deny">Denegar</string>
+    <string name="permission_settings">Ir a Ajustes</string>
+
+    <!-- Notifications -->
+    <string name="notification_channel_alerts">Alertas familiares</string>
+    <string name="notification_channel_alerts_desc">Notificaciones sobre la ubicación de tu familia</string>
+    <string name="notification_channel_service">Servicio de ubicación</string>
+    <string name="notification_channel_service_desc">Notificación del servicio en segundo plano</string>
+    <string name="notification_service_title">FamilyTrack activo</string>
+    <string name="notification_service_text">Compartiendo tu ubicación con la familia</string>
+
+    <!-- Errors -->
+    <string name="error_generic">Ha ocurrido un error</string>
+    <string name="error_network">Error de conexión</string>
+    <string name="error_location">No se pudo obtener la ubicación</string>
+    <string name="error_registration">Error al registrar dispositivo</string>
+    <string name="error_connection">Error de conexión</string>
+
+    <!-- Actions -->
+    <string name="action_retry">Reintentar</string>
+    <string name="action_cancel">Cancelar</string>
+    <string name="cancel">Cancelar</string>
+    <string name="action_save">Guardar</string>
+    <string name="action_delete">Eliminar</string>
+    <string name="action_confirm">Confirmar</string>
+    <string name="action_back">Volver</string>
+
+    <!-- Time -->
+    <string name="time_just_now">Justo ahora</string>
+    <string name="time_minutes_ago">Hace %1$d min</string>
+    <string name="time_hours_ago">Hace %1$d h</string>
+    <string name="time_days_ago">Hace %1$d días</string>
+    <string name="time_never">Nunca</string>
+
+    <!-- Splash -->
+    <string name="splash_tagline">Tu familia, siempre cerca</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,119 +3,232 @@
     <string name="app_name">FamilyTrack</string>
 
     <!-- Navigation -->
-    <string name="nav_home">Inicio</string>
-    <string name="nav_map">Mapa</string>
-    <string name="nav_family">Familia</string>
-    <string name="nav_settings">Ajustes</string>
+    <string name="nav_home">Home</string>
+    <string name="nav_map">Map</string>
+    <string name="nav_family">Family</string>
+    <string name="nav_settings">Settings</string>
 
     <!-- Home Screen -->
-    <string name="home_title">Mi Ubicación</string>
-    <string name="home_status_active">Activo</string>
-    <string name="home_status_inactive">Inactivo</string>
-    <string name="home_sharing_location">Compartiendo ubicación</string>
-    <string name="home_not_sharing">Ubicación pausada</string>
-    <string name="home_last_update">Última actualización: %1$s</string>
-    <string name="home_interval">Intervalo: %1$d min</string>
+    <string name="home_title">My Location</string>
+    <string name="home_status_active">Active</string>
+    <string name="home_status_inactive">Inactive</string>
+    <string name="home_sharing_location">Sharing location</string>
+    <string name="home_not_sharing">Location paused</string>
+    <string name="home_last_update">Last update: %1$s</string>
+    <string name="home_interval">Interval: %1$d min</string>
+    <string name="home_quick_messages">Quick messages</string>
+    <string name="home_sos_title">Send SOS</string>
+    <string name="home_sos_confirm">An emergency alert will be sent to all your family members. Continue?</string>
+    <string name="home_sos_send">Send SOS</string>
+    <string name="home_sos_sent">SOS sent to your family</string>
+    <string name="home_sos_error">Error sending SOS</string>
+    <string name="home_message_sent">Message sent</string>
+    <string name="home_message_error">Error sending message</string>
+
+    <!-- Quick Messages -->
+    <string name="quick_msg_im_fine">I\'m fine</string>
+    <string name="quick_msg_going_home">Going home</string>
+    <string name="quick_msg_arriving">Almost there</string>
+    <string name="quick_msg_call_me">Call me</string>
+    <string name="quick_msg_will_be_late">Running late</string>
 
     <!-- Map Screen -->
-    <string name="map_title">Mapa Familiar</string>
-    <string name="map_loading">Cargando ubicaciones…</string>
-    <string name="map_no_locations">Sin ubicaciones disponibles</string>
+    <string name="map_title">Family Map</string>
+    <string name="map_loading">Loading locations…</string>
+    <string name="map_no_locations">No locations available</string>
 
     <!-- Family Screen -->
-    <string name="family_title">Mi Familia</string>
-    <string name="family_member_online">En línea</string>
-    <string name="family_member_offline">Sin conexión</string>
-    <string name="family_member_last_seen">Visto: %1$s</string>
-    <string name="family_add_member">Añadir miembro</string>
-    <string name="family_empty">No hay miembros registrados</string>
-    <string name="family_notify_sent">Notificación enviada a %1$s</string>
+    <string name="family_title">My Family</string>
+    <string name="family_member_online">Online</string>
+    <string name="family_member_offline">Offline</string>
+    <string name="family_member_last_seen">Seen: %1$s</string>
+    <string name="family_add_member">Add member</string>
+    <string name="family_empty">No registered members</string>
+    <string name="family_notify_sent">Notification sent to %1$s</string>
     <string name="family_role_admin">Admin</string>
     <string name="family_role_monitor">Monitor</string>
-    <string name="family_role_monitored">Monitoreado</string>
+    <string name="family_role_monitored">Monitored</string>
+    <string name="family_notify">Notify</string>
 
     <!-- Settings Screen -->
-    <string name="settings_title">Ajustes</string>
-    <string name="settings_location">Ubicación</string>
-    <string name="settings_location_enabled">Compartir ubicación</string>
-    <string name="settings_location_interval">Intervalo de actualización</string>
-    <string name="settings_notifications">Notificaciones</string>
-    <string name="settings_notifications_enabled">Recibir alertas</string>
-    <string name="settings_notifications_sound">Sonido</string>
-    <string name="settings_notifications_vibrate">Vibración</string>
-    <string name="settings_account">Cuenta</string>
-    <string name="settings_device_name">Nombre del dispositivo</string>
-    <string name="settings_user_name">Tu nombre</string>
-    <string name="settings_logout">Cerrar sesión</string>
-    <string name="settings_about">Acerca de</string>
-    <string name="settings_version">Versión %1$s</string>
+    <string name="settings_title">Settings</string>
+    <string name="settings_location">Location</string>
+    <string name="settings_location_enabled">Share location</string>
+    <string name="settings_location_interval">Update interval</string>
+    <string name="settings_notifications">Notifications</string>
+    <string name="settings_notifications_enabled">Receive alerts</string>
+    <string name="settings_notifications_sound">Sound</string>
+    <string name="settings_notifications_vibrate">Vibration</string>
+    <string name="settings_appearance">Appearance</string>
+    <string name="settings_theme">Theme</string>
+    <string name="settings_theme_system">System</string>
+    <string name="settings_theme_light">Light</string>
+    <string name="settings_theme_dark">Dark</string>
+    <string name="settings_security">Security</string>
+    <string name="settings_pin_lock">PIN lock</string>
+    <string name="settings_biometric">Biometric unlock</string>
+    <string name="settings_manage_permissions">Manage permissions</string>
+    <string name="settings_account">Account</string>
+    <string name="settings_device_name">Device name</string>
+    <string name="settings_user_name">Your name</string>
+    <string name="settings_edit_profile">Edit profile</string>
+    <string name="settings_family_chat">Family chat</string>
+    <string name="settings_logout">Log out</string>
+    <string name="settings_about">About</string>
+    <string name="settings_version">Version %1$s</string>
     <string name="settings_interval_value">%1$d min</string>
-    <string name="settings_device_info">Dispositivo</string>
-    <string name="settings_device_id">ID dispositivo: %1$d</string>
-    <string name="settings_user_id">ID usuario: %1$d</string>
-    <string name="settings_registered">Registrado: %1$s</string>
-    <string name="settings_last_update">Última ubicación: %1$s</string>
-    <string name="settings_token">Token FCM</string>
-    <string name="settings_actions">Acciones</string>
-    <string name="settings_send_location_now">Enviar ubicación ahora</string>
-    <string name="settings_test_notification">Probar notificación</string>
+    <string name="settings_device_info">Device</string>
+    <string name="settings_device_id">Device ID: %1$d</string>
+    <string name="settings_user_id">User ID: %1$d</string>
+    <string name="settings_registered">Registered: %1$s</string>
+    <string name="settings_last_update">Last location: %1$s</string>
+    <string name="settings_token">FCM Token</string>
+    <string name="settings_actions">Actions</string>
+    <string name="settings_send_location_now">Send location now</string>
+    <string name="settings_test_notification">Test notification</string>
+    <string name="settings_yes">Yes</string>
+    <string name="settings_no">No</string>
+    <string name="settings_never">Never</string>
 
-    <!-- Safe Zones -->
-    <string name="safe_zones_title">Zonas Seguras</string>
-    <string name="safe_zones_empty">No hay zonas seguras configuradas</string>
-    <string name="safe_zone_add">Añadir zona</string>
-    <string name="safe_zone_name">Nombre de la zona</string>
-    <string name="safe_zone_lat">Latitud</string>
-    <string name="safe_zone_lng">Longitud</string>
-    <string name="safe_zone_radius">Radio (metros)</string>
-    <string name="safe_zone_radius_value">%1$d m</string>
-    <string name="safe_zone_delete">Eliminar zona</string>
-    <string name="safe_zone_delete_confirm">¿Eliminar la zona \"%1$s\"?</string>
+    <!-- Profile -->
+    <string name="profile_title">My Profile</string>
+    <string name="profile_name">Name</string>
+    <string name="profile_role">Role</string>
+    <string name="profile_family">Family</string>
+    <string name="profile_invite_code">Invite code</string>
+    <string name="profile_save">Save</string>
+    <string name="profile_saved">Profile saved</string>
+    <string name="profile_copy">Copy</string>
 
-    <!-- Alerts -->
-    <string name="alert_zone_exit_title">Salida de zona segura</string>
-    <string name="alert_zone_exit_body">%1$s ha salido de %2$s</string>
-    <string name="alert_zone_entry_title">Entrada a zona segura</string>
-    <string name="alert_zone_entry_body">%1$s ha llegado a %2$s</string>
-    <string name="alert_offline_title">Dispositivo sin conexión</string>
-    <string name="alert_offline_body">%1$s no ha reportado ubicación en las últimas 24 horas</string>
+    <!-- Chat -->
+    <string name="chat_title">Family Chat</string>
+    <string name="chat_send">Send</string>
+    <string name="chat_hint">Write a message…</string>
+    <string name="chat_empty">No messages yet</string>
+
+    <!-- Photos -->
+    <string name="photos_title">Photos</string>
+    <string name="photos_empty">No photos</string>
+    <string name="photos_sent">Photo sent</string>
+    <string name="photos_send_error">Error sending photo</string>
+
+    <!-- Route History -->
+    <string name="route_history_title">Route History</string>
+    <string name="route_history_prev_day">Previous day</string>
+    <string name="route_history_next_day">Next day</string>
+    <string name="route_history_points">%1$d recorded points</string>
+    <string name="route_history_empty">No route data for this day</string>
+
+    <!-- Onboarding -->
+    <string name="onboarding_skip">Skip</string>
+    <string name="onboarding_next">Next</string>
+    <string name="onboarding_start">Get Started</string>
+    <string name="onboarding_title_1">Your family, always close</string>
+    <string name="onboarding_desc_1">Keep your family connected and safe at all times</string>
+    <string name="onboarding_title_2">Real-time location</string>
+    <string name="onboarding_desc_2">Share your location and know where your loved ones are</string>
+    <string name="onboarding_title_3">Privacy guaranteed</string>
+    <string name="onboarding_desc_3">Only your family can see your location. Your data is protected</string>
+
+    <!-- Family Setup -->
+    <string name="family_setup_title">Set up your family</string>
+    <string name="family_setup_create">Create family</string>
+    <string name="family_setup_join">Join a family</string>
+    <string name="family_setup_create_title">Create new family</string>
+    <string name="family_setup_join_title">Join family</string>
+    <string name="family_setup_family_name">Family name</string>
+    <string name="family_setup_your_name">Your name</string>
+    <string name="family_setup_invite_code">Invite code</string>
+    <string name="family_setup_admin_note">You will be the family administrator</string>
+    <string name="family_setup_create_btn">Create family</string>
+    <string name="family_setup_join_btn">Join</string>
+    <string name="family_setup_success_title">Family created!</string>
+    <string name="family_setup_share_code">Share this code with your family:</string>
+    <string name="family_setup_continue">Continue</string>
 
     <!-- Permissions -->
-    <string name="permission_location_title">Permiso de ubicación</string>
-    <string name="permission_location_rationale">FamilyTrack necesita acceso a tu ubicación para compartirla con tu familia.</string>
-    <string name="permission_location_background_title">Ubicación en segundo plano</string>
-    <string name="permission_location_background_rationale">Para compartir tu ubicación incluso cuando la app está cerrada, necesitamos permiso de ubicación en segundo plano.</string>
-    <string name="permission_notification_title">Permiso de notificaciones</string>
-    <string name="permission_notification_rationale">Necesitamos permiso para enviarte alertas importantes sobre tu familia.</string>
-    <string name="permission_grant">Conceder</string>
-    <string name="permission_deny">Denegar</string>
-    <string name="permission_settings">Ir a Ajustes</string>
+    <string name="permissions_title">Permissions</string>
+    <string name="permissions_location">Location</string>
+    <string name="permissions_notifications">Notifications</string>
+    <string name="permissions_background_location">Background location</string>
+    <string name="permissions_battery_optimization">Battery optimization</string>
+    <string name="permissions_granted">Granted</string>
+    <string name="permissions_denied">Denied</string>
+    <string name="permissions_grant">Grant</string>
+    <string name="permissions_open_settings">Open settings</string>
+    <string name="permissions_continue">Continue</string>
+
+    <!-- PIN -->
+    <string name="pin_title">PIN Lock</string>
+    <string name="pin_enter">Enter your PIN</string>
+    <string name="pin_create">Create a 4-digit PIN</string>
+    <string name="pin_confirm">Confirm your PIN</string>
+    <string name="pin_mismatch">PINs don\'t match. Try again.</string>
+    <string name="pin_biometric">Biometric</string>
+    <string name="pin_delete">Delete</string>
+
+    <!-- Safe Zones -->
+    <string name="safe_zones_title">Safe Zones</string>
+    <string name="safe_zones_empty">No safe zones configured</string>
+    <string name="safe_zone_add">Add zone</string>
+    <string name="safe_zone_name">Zone name</string>
+    <string name="safe_zone_lat">Latitude</string>
+    <string name="safe_zone_lng">Longitude</string>
+    <string name="safe_zone_radius">Radius (meters)</string>
+    <string name="safe_zone_radius_value">%1$d m</string>
+    <string name="safe_zone_delete">Delete zone</string>
+    <string name="safe_zone_delete_confirm">Delete zone \"%1$s\"?</string>
+
+    <!-- Alerts -->
+    <string name="alert_zone_exit_title">Safe zone exit</string>
+    <string name="alert_zone_exit_body">%1$s has left %2$s</string>
+    <string name="alert_zone_entry_title">Safe zone entry</string>
+    <string name="alert_zone_entry_body">%1$s has arrived at %2$s</string>
+    <string name="alert_offline_title">Device offline</string>
+    <string name="alert_offline_body">%1$s has not reported location in the last 24 hours</string>
+
+    <!-- Permissions Dialog -->
+    <string name="permission_location_title">Location permission</string>
+    <string name="permission_location_rationale">FamilyTrack needs access to your location to share it with your family.</string>
+    <string name="permission_location_background_title">Background location</string>
+    <string name="permission_location_background_rationale">To share your location even when the app is closed, we need background location permission.</string>
+    <string name="permission_notification_title">Notification permission</string>
+    <string name="permission_notification_rationale">We need permission to send you important alerts about your family.</string>
+    <string name="permission_grant">Grant</string>
+    <string name="permission_deny">Deny</string>
+    <string name="permission_settings">Go to Settings</string>
 
     <!-- Notifications -->
-    <string name="notification_channel_alerts">Alertas familiares</string>
-    <string name="notification_channel_alerts_desc">Notificaciones sobre la ubicación de tu familia</string>
-    <string name="notification_channel_service">Servicio de ubicación</string>
-    <string name="notification_channel_service_desc">Notificación del servicio en segundo plano</string>
-    <string name="notification_service_title">FamilyTrack activo</string>
-    <string name="notification_service_text">Compartiendo tu ubicación con la familia</string>
+    <string name="notification_channel_alerts">Family alerts</string>
+    <string name="notification_channel_alerts_desc">Notifications about your family\'s location</string>
+    <string name="notification_channel_service">Location service</string>
+    <string name="notification_channel_service_desc">Background service notification</string>
+    <string name="notification_service_title">FamilyTrack active</string>
+    <string name="notification_service_text">Sharing your location with family</string>
 
     <!-- Errors -->
-    <string name="error_generic">Ha ocurrido un error</string>
-    <string name="error_network">Error de conexión</string>
-    <string name="error_location">No se pudo obtener la ubicación</string>
-    <string name="error_registration">Error al registrar dispositivo</string>
+    <string name="error_generic">An error occurred</string>
+    <string name="error_network">Connection error</string>
+    <string name="error_location">Could not get location</string>
+    <string name="error_registration">Device registration error</string>
+    <string name="error_connection">Connection error</string>
 
     <!-- Actions -->
-    <string name="action_retry">Reintentar</string>
-    <string name="action_cancel">Cancelar</string>
-    <string name="cancel">Cancelar</string>
-    <string name="action_save">Guardar</string>
-    <string name="action_delete">Eliminar</string>
-    <string name="action_confirm">Confirmar</string>
+    <string name="action_retry">Retry</string>
+    <string name="action_cancel">Cancel</string>
+    <string name="cancel">Cancel</string>
+    <string name="action_save">Save</string>
+    <string name="action_delete">Delete</string>
+    <string name="action_confirm">Confirm</string>
+    <string name="action_back">Back</string>
 
     <!-- Time -->
-    <string name="time_just_now">Justo ahora</string>
-    <string name="time_minutes_ago">Hace %1$d min</string>
-    <string name="time_hours_ago">Hace %1$d h</string>
-    <string name="time_days_ago">Hace %1$d días</string>
+    <string name="time_just_now">Just now</string>
+    <string name="time_minutes_ago">%1$d min ago</string>
+    <string name="time_hours_ago">%1$d h ago</string>
+    <string name="time_days_ago">%1$d days ago</string>
+    <string name="time_never">Never</string>
+
+    <!-- Splash -->
+    <string name="splash_tagline">Your family, always close</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add English as default language (values/strings.xml)
- Add Spanish locale (values-es/strings.xml)
- Add 60+ new string resources for previously hardcoded UI text
- Replace hardcoded strings in SettingsScreen, HomeScreen, OnboardingScreen, RouteHistoryScreen

## Test plan
- [ ] Verify English text shows when device is set to English
- [ ] Verify Spanish text shows when device is set to Spanish
- [ ] Verify all screens display correctly in both languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)